### PR TITLE
[Feat] getScrapCourseByUser

### DIFF
--- a/src/main/java/org/runnect/server/common/exception/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/exception/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus {
     NOT_FOUND_USER_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다"),
     NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 이미지 파일입니다"),
     NOT_FOUND_PUBLICCOURSE_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 public course id입니다."),
+    NOT_FOUND_SCRAP_EXCEPTION(HttpStatus.BAD_REQUEST, "스크랩한 코스가 없습니다."),
 
     /**
      * 409 CONFLICT

--- a/src/main/java/org/runnect/server/common/exception/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/exception/SuccessStatus.java
@@ -16,6 +16,7 @@ public enum SuccessStatus {
     CREATE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 성공"),
     DELETE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 취소 성공"),
     READ_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 조회 성공"),
+    GET_SCRAP_COURSE_BY_USER_SUCCESS(HttpStatus.OK, "스크랩한 코스 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/scrap/controller/ScrapController.java
+++ b/src/main/java/org/runnect/server/scrap/controller/ScrapController.java
@@ -1,9 +1,11 @@
 package org.runnect.server.scrap.controller;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.exception.SuccessStatus;
 import org.runnect.server.scrap.dto.request.CreateAndDeleteScrapRequestDto;
+import org.runnect.server.scrap.dto.response.GetScrapCourseResponseDto;
 import org.runnect.server.scrap.service.ScrapService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -25,5 +27,11 @@ public class ScrapController {
             return ApiResponseDto.success(SuccessStatus.CREATE_SCRAP_SUCCESS);
         }
         return ApiResponseDto.success(SuccessStatus.DELETE_SCRAP_SUCCESS);
+    }
+
+    @GetMapping("scrap/user")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetScrapCourseResponseDto> getScrapCourseByUser(@RequestHeader Long userId) {
+        return ApiResponseDto.success(SuccessStatus.GET_SCRAP_COURSE_BY_USER_SUCCESS, scrapService.getScrapCourseByUser(userId));
     }
 }

--- a/src/main/java/org/runnect/server/scrap/dto/response/DepartureResponse.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/DepartureResponse.java
@@ -1,0 +1,18 @@
+package org.runnect.server.scrap.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DepartureResponse {
+    private String region;
+    private String city;
+
+    public static DepartureResponse of(String region, String city) {
+        return new DepartureResponse(region, city);
+    }
+}

--- a/src/main/java/org/runnect/server/scrap/dto/response/GetScrapCourseResponseDto.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/GetScrapCourseResponseDto.java
@@ -1,0 +1,23 @@
+package org.runnect.server.scrap.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetScrapCourseResponseDto {
+    UserResponse user;
+
+    // 명세서상 response에서 Scraps로 앞 문자가 대문자라서 @JsonProperty로 리턴시 이름 지정
+    @JsonProperty("Scraps")
+    List<ScrapResponse> Scraps;
+
+    public static GetScrapCourseResponseDto of (UserResponse user, List<ScrapResponse> Scraps) {
+        return new GetScrapCourseResponseDto(user, Scraps);
+    }
+}

--- a/src/main/java/org/runnect/server/scrap/dto/response/GetScrapCourseResponseDto.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/GetScrapCourseResponseDto.java
@@ -13,9 +13,7 @@ import java.util.List;
 public class GetScrapCourseResponseDto {
     UserResponse user;
 
-    // 명세서상 response에서 Scraps로 앞 문자가 대문자라서 @JsonProperty로 리턴시 이름 지정
-    @JsonProperty("Scraps")
-    List<ScrapResponse> Scraps;
+    List<ScrapResponse> scraps;
 
     public static GetScrapCourseResponseDto of (UserResponse user, List<ScrapResponse> Scraps) {
         return new GetScrapCourseResponseDto(user, Scraps);

--- a/src/main/java/org/runnect/server/scrap/dto/response/ScrapResponse.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/ScrapResponse.java
@@ -1,0 +1,22 @@
+package org.runnect.server.scrap.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScrapResponse {
+    private Long id;
+    private Long publicCourseId;
+    private Long courseId;
+    private String title;
+    private String image;
+    private DepartureResponse departure;
+
+    public static ScrapResponse of (Long id, Long publicCourseId, Long courseId, String title, String image, DepartureResponse departure) {
+        return new ScrapResponse(id, publicCourseId, courseId, title, image, departure);
+    }
+}

--- a/src/main/java/org/runnect/server/scrap/dto/response/UserResponse.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/UserResponse.java
@@ -1,0 +1,17 @@
+package org.runnect.server.scrap.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserResponse {
+    private Long userId;
+
+    public static UserResponse of(Long userId) {
+        return new UserResponse(userId);
+    }
+}

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -4,6 +4,7 @@ import org.runnect.server.scrap.entity.Scrap;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScrapRepository extends Repository<Scrap, Long> {
@@ -13,6 +14,9 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
     // READ
     @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse WHERE s.runnectUser.id = :userId AND s.publicCourse.id = :publicCourseId")
     Optional<Scrap> findByUserIdAndPublicCourseId(Long userId, Long publicCourseId);
+
+    @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse pc JOIN FETCH pc.course c WHERE s.runnectUser.id = :userId AND s.scrapTF = true")
+    Optional<List<Scrap>> findAllByUserIdAndScrapTF(Long userId);
 
     // DELETE
 }

--- a/src/main/java/org/runnect/server/scrap/service/ScrapService.java
+++ b/src/main/java/org/runnect/server/scrap/service/ScrapService.java
@@ -6,6 +6,10 @@ import org.runnect.server.common.exception.NotFoundException;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.publicCourse.repository.PublicCourseRepository;
 import org.runnect.server.scrap.dto.request.CreateAndDeleteScrapRequestDto;
+import org.runnect.server.scrap.dto.response.DepartureResponse;
+import org.runnect.server.scrap.dto.response.GetScrapCourseResponseDto;
+import org.runnect.server.scrap.dto.response.ScrapResponse;
+import org.runnect.server.scrap.dto.response.UserResponse;
 import org.runnect.server.scrap.entity.Scrap;
 import org.runnect.server.scrap.repository.ScrapRepository;
 import org.runnect.server.user.entity.RunnectUser;
@@ -14,7 +18,9 @@ import org.runnect.server.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -47,5 +53,24 @@ public class ScrapService {
         else {
             scrap.updateScrapTF(false);
         }
+    }
+
+    public GetScrapCourseResponseDto getScrapCourseByUser(Long userId) {
+        List<Scrap> scraps = scrapRepository.findAllByUserIdAndScrapTF(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_SCRAP_EXCEPTION, ErrorStatus.NOT_FOUND_SCRAP_EXCEPTION.getMessage()));
+
+        List<ScrapResponse> scrapResponses = scraps.stream()
+                .map(scrap -> ScrapResponse.of(
+                        scrap.getId(),
+                        scrap.getPublicCourse().getId(),
+                        scrap.getPublicCourse().getCourse().getId(),
+                        scrap.getPublicCourse().getTitle(),
+                        scrap.getPublicCourse().getCourse().getImage(),
+                        DepartureResponse.of(
+                                scrap.getPublicCourse().getCourse().getDepartureRegion(),
+                                scrap.getPublicCourse().getCourse().getDepartureCity())
+                )).collect(Collectors.toList());
+
+        return GetScrapCourseResponseDto.of(UserResponse.of(userId), scrapResponses);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #21 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse pc JOIN FETCH pc.course c WHERE s.runnectUser.id = :userId AND s.scrapTF = true") 쿼리를 사용하여 user의 scrap들을 불러올 때 publicCourse와 course테이블도 함께 불러오도록 했습니다.
- service단에서 for문을 사용하지 않고 stream과 map을 이용해 데이터들을 하나씩 매핑해주었씁니다ㅎ

### 🤯 주의할 점이 있나요?

---
![image](https://github.com/Runnect/Runnect-Spring-Boot-Server/assets/87180069/3062db61-4f37-40c9-800e-ba64d6bc7e22)
명세서 상에서는 scraps의 시작이 대문자(Scraps)로 되어 있어서 이를 반영하기 위해 GetScrapCourseResponseDto에서도 Scraps로 작성해주었는데, 자바 객체 특성때문인지 자동으로 소문자(scraps)로 바뀌더라구요. 
따라서 @JsonProperty 어노테이션으로 Scraps로 이름을 지정해주긴 했는데, 이렇게 되면 아래 사진처럼  Scraps와 scraps 둘 다 response로 반환되는 문제가 발생합니다 ㅠㅠ 근데 현재로써는 달리 방법이 없는 듯 합니다!! ㅠㅠ
![image](https://github.com/Runnect/Runnect-Spring-Boot-Server/assets/87180069/1f4d006c-9e1d-440c-aea1-ca1d636095b1)
