### PR TITLE
[Fix] Course Entity에 title 추가

### DIFF
--- a/src/main/java/org/runnect/server/course/entity/Course.java
+++ b/src/main/java/org/runnect/server/course/entity/Course.java
@@ -26,6 +26,9 @@ public class Course extends AuditingTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private RunnectUser runnectUser;
 
+    @Column(length = 40)
+    private String title;
+
     @Column(nullable = false, length = 10)
     private String departureRegion;
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

closes #28 

### 🤔 어떻게 이슈를 해결했나요?

---

- course entity에 title 컬럼을 추가했습니다.

### 🤯 주의할 점이 있나요?

---
- title 컬럼을 추가하면 현재는 null로 다 초기화가 되는데, 이걸 저희가 원하는 값으로 채워주기 위해서 디비 콘솔에서 직접 쿼리문을 작성하는 방법을 생각해보았는데 어떤가요! 
다만 저의 역량 한계로.. 공개코스와 비공개코스 타이틀을 한번에 수정할 쿼리는.. ㅠㅠ 혹시 아이디어가 있다면 알려주세용!! 대책으로 두번에 걸쳐서 수정하는 쿼리문을 짜봤습니다 검토 부탁드려요!!!
``` 
// 1. 공유된 코스는 public course 테이블에서 title을 가져옴.
UPDATE course AS c
SET title = pc.title
FROM public_course as pc
WHERE pc.course_id = c.id;

// 2. private 코스는 region와 city로 title을 작성.
UPDATE course AS c
SET title = CONCAT(c.departure_region, ' ', c.departure_city)
FROM public_course AS pc
WHERE c.id NOT IN (SELECT course_id FROM public_course);
```
![image](https://github.com/Runnect/Runnect-Spring-Boot-Server/assets/87180069/5ca7c747-4f9e-46d2-862d-9b937b03acb1)

