### PR TITLE
[Feat] deletePublicCourse

### DIFF
--- a/src/main/java/org/runnect/server/common/entity/AuditingTimeEntity.java
+++ b/src/main/java/org/runnect/server/common/entity/AuditingTimeEntity.java
@@ -1,13 +1,12 @@
 package org.runnect.server.common.entity;
 
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -20,4 +19,8 @@ public abstract class AuditingTimeEntity {
     private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt;
+
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/runnect/server/common/exception/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/exception/ErrorStatus.java
@@ -31,6 +31,10 @@ public enum ErrorStatus {
     INVALID_REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
 
+    /**
+     * 403 FORBIDDEN
+     */
+    PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION(HttpStatus.FORBIDDEN, "퍼블릭 코스를 삭제할 권한이 존재하지 않습니다."),
 
     /**
      * 404 NOT FOUND

--- a/src/main/java/org/runnect/server/common/exception/PermissionDeniedException.java
+++ b/src/main/java/org/runnect/server/common/exception/PermissionDeniedException.java
@@ -1,0 +1,8 @@
+package org.runnect.server.common.exception;
+
+public class PermissionDeniedException extends BasicException {
+
+    public PermissionDeniedException(ErrorStatus errorStatus, String message) {
+        super(errorStatus, message);
+    }
+}

--- a/src/main/java/org/runnect/server/common/exception/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/exception/SuccessStatus.java
@@ -24,6 +24,7 @@ public enum SuccessStatus {
     UPDATE_USER_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경에 성공했습니다."),
     UPDATE_COURSE_SUCCESS(HttpStatus.OK, "내가 그린 코스 제목 수정 성공"),
     GET_USER_PROFILE_SUCCESS(HttpStatus.OK, "유저 프로필 조회에 성공했습니다."),
+    DELETE_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "퍼블릭 코스 삭제에 성공했습니다."),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/course/entity/Course.java
+++ b/src/main/java/org/runnect/server/course/entity/Course.java
@@ -1,17 +1,24 @@
 package org.runnect.server.course.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.runnect.server.common.entity.AuditingTimeEntity;
-import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.record.entity.Record;
 import org.runnect.server.user.entity.RunnectUser;
-
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -23,7 +30,7 @@ public class Course extends AuditingTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id")
     private RunnectUser runnectUser;
 
     @Column(length = 40)

--- a/src/main/java/org/runnect/server/course/entity/Course.java
+++ b/src/main/java/org/runnect/server/course/entity/Course.java
@@ -2,7 +2,6 @@ package org.runnect.server.course.entity;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -63,7 +62,7 @@ public class Course extends AuditingTimeEntity {
     @Column(nullable = false)
     private String path;
 
-    @OneToMany(mappedBy = "course", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "course")
     private List<Record> records = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -1,0 +1,34 @@
+package org.runnect.server.publicCourse.controller;
+
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.common.dto.ApiResponseDto;
+import org.runnect.server.common.exception.SuccessStatus;
+import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
+import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.service.PublicCourseService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/public-course")
+public class PublicCourseController {
+
+    private final PublicCourseService publicCourseService;
+
+    @PutMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<DeletePublicCoursesResponseDto> deletePublicCourses(
+        @RequestHeader final Long userId,
+        @Valid @RequestBody final DeletePublicCoursesRequestDto deletePublicCoursesRequestDto
+    ) {
+        return ApiResponseDto.success(SuccessStatus.DELETE_PUBLIC_COURSE_SUCCESS,
+            publicCourseService.deletePublicCourses(userId, deletePublicCoursesRequestDto));
+    }
+}

--- a/src/main/java/org/runnect/server/publicCourse/dto/request/DeletePublicCoursesRequestDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/request/DeletePublicCoursesRequestDto.java
@@ -1,0 +1,17 @@
+package org.runnect.server.publicCourse.dto.request;
+
+import java.util.List;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeletePublicCoursesRequestDto {
+
+    @Size(min = 1)
+    private List<Long> publicCourseIdList;
+}

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/DeletePublicCoursesResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/DeletePublicCoursesResponseDto.java
@@ -1,0 +1,18 @@
+package org.runnect.server.publicCourse.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeletePublicCoursesResponseDto {
+
+    private int deletedPublicCourseCount;
+
+    public static DeletePublicCoursesResponseDto from(final int deletedPublicCourseCount) {
+        return new DeletePublicCoursesResponseDto(deletedPublicCourseCount);
+    }
+}

--- a/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
@@ -37,10 +37,10 @@ public class PublicCourse extends AuditingTimeEntity {
     @Column(nullable = false)
     private String description;
 
-    @OneToMany(mappedBy = "publicCourse", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "publicCourse")
     private List<Scrap> scraps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "publicCourse", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "publicCourse")
     private List<Record> records = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
@@ -24,7 +24,7 @@ public class PublicCourse extends AuditingTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id")
     private RunnectUser runnectUser;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -1,5 +1,6 @@
 package org.runnect.server.publicCourse.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.runnect.server.publicCourse.entity.PublicCourse;
@@ -19,6 +20,8 @@ public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Lon
 
     @Query("select pc from PublicCourse pc join fetch pc.course where pc.runnectUser = :user")
     List<PublicCourse> findPublicCoursesByRunnectUser(RunnectUser user);
+
+    List<PublicCourse> findByIdIn(Collection<Long> ids);
 
     // DELETE
 }

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -1,0 +1,61 @@
+package org.runnect.server.publicCourse.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.common.exception.ErrorStatus;
+import org.runnect.server.common.exception.NotFoundException;
+import org.runnect.server.common.exception.PermissionDeniedException;
+import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
+import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.entity.PublicCourse;
+import org.runnect.server.publicCourse.repository.PublicCourseRepository;
+import org.runnect.server.record.entity.Record;
+import org.runnect.server.scrap.repository.ScrapRepository;
+import org.runnect.server.user.entity.RunnectUser;
+import org.runnect.server.user.exception.userException.NotFoundUserException;
+import org.runnect.server.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PublicCourseService {
+
+    private final PublicCourseRepository publicCourseRepository;
+    private final UserRepository userRepository;
+    private final ScrapRepository scrapRepository;
+
+    @Transactional
+    public DeletePublicCoursesResponseDto deletePublicCourses(
+        Long userId,
+        DeletePublicCoursesRequestDto requestDto
+    ) {
+        RunnectUser user = userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
+                ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        List<PublicCourse> publicCourses = publicCourseRepository.findByIdIn(
+            requestDto.getPublicCourseIdList());
+
+        
+        if (publicCourses.size() != requestDto.getPublicCourseIdList().size()) {
+            throw new NotFoundException(ErrorStatus.NOT_FOUND_PUBLICCOURSE_EXCEPTION, ErrorStatus.NOT_FOUND_PUBLICCOURSE_EXCEPTION.getMessage());
+        }
+
+        publicCourses.stream()
+            .filter(pc -> !pc.getRunnectUser().equals(user))
+            .findAny()
+            .ifPresent(pc -> {
+                throw new PermissionDeniedException(
+                    ErrorStatus.PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION,
+                    ErrorStatus.PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION.getMessage());
+            });
+
+
+        scrapRepository.deleteByPublicCourseIn(publicCourses);
+        publicCourses.forEach(publicCourse -> publicCourse.getRecords().forEach(Record::setPublicCourseNull));
+        publicCourses.forEach(PublicCourse::updateDeletedAt);
+
+        return DeletePublicCoursesResponseDto.from(publicCourses.size());
+    }
+}

--- a/src/main/java/org/runnect/server/record/entity/Record.java
+++ b/src/main/java/org/runnect/server/record/entity/Record.java
@@ -62,4 +62,7 @@ public class Record extends AuditingTimeEntity {
         this.title = title;
     }
 
+    public void setPublicCourseNull() {
+        this.publicCourse = null;
+    }
 }

--- a/src/main/java/org/runnect/server/record/entity/Record.java
+++ b/src/main/java/org/runnect/server/record/entity/Record.java
@@ -1,18 +1,22 @@
 package org.runnect.server.record.entity;
 
+import java.sql.Time;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.DynamicUpdate;
 import org.runnect.server.common.entity.AuditingTimeEntity;
 import org.runnect.server.course.entity.Course;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.user.entity.RunnectUser;
-
-import javax.persistence.*;
-import java.sql.Time;
-import java.time.LocalTime;
 
 @Getter
 @Entity
@@ -28,7 +32,7 @@ public class Record extends AuditingTimeEntity {
     private RunnectUser runnectUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id", nullable = false)
+    @JoinColumn(name = "course_id")
     private Course course;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -1,13 +1,13 @@
 package org.runnect.server.scrap.repository;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.scrap.entity.Scrap;
 import org.runnect.server.user.entity.RunnectUser;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface ScrapRepository extends Repository<Scrap, Long> {
     // CREATE
@@ -24,7 +24,7 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
 
     Boolean existsByPublicCourseAndRunnectUser(PublicCourse publicCourse, RunnectUser runnectUser);
 
-
-
     // DELETE
+    Long deleteByPublicCourseIn(Collection<PublicCourse> publicCourses);
+
 }

--- a/src/main/java/org/runnect/server/user/entity/RunnectUser.java
+++ b/src/main/java/org/runnect/server/user/entity/RunnectUser.java
@@ -2,7 +2,6 @@ package org.runnect.server.user.entity;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -71,16 +70,16 @@ public class RunnectUser extends AuditingTimeEntity {
     @Column(nullable = false)
     private Long createdScrap;
 
-    @OneToMany(mappedBy = "runnectUser", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "runnectUser")
     private List<Course> courses = new ArrayList<>();
 
-    @OneToMany(mappedBy = "runnectUser", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "runnectUser")
     private List<Record> records = new ArrayList<>();
 
-    @OneToMany(mappedBy = "runnectUser", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "runnectUser")
     private List<Scrap> scraps = new ArrayList<>();
 
-    @OneToMany(mappedBy = "runnectUser", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "runnectUser")
     private List<UserStamp> userStamps = new ArrayList<>();
 
     @Builder


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
#41 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

1. 요청 아이디 리스트를 이용해 public course list를 가져온다. 이때 둘의 사이즈가 다르면 `NotFoundException` 발생
2. 가져온 public course list를 순회하며 퍼블릭 코스의 유저와 요청 유저를 비교한다. 이때 다르면 `PermissionDeniedException` 발생
3. 관련 스크랩 모두 삭제
4. 관련 기록에서 public course set null
5. 퍼블릭 코스 deleted_at update

### 🤯 주의할 점이 있나요?

---
- 조회할 때 deleted_at이 null인 것들만 가져와야 합니다! (코스 조회 API 수정 예정..!)
- 나중에 개선 해야 할 수도....

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
