### PR TITLE
[Feat] deleteRecord 

### DIFF
--- a/src/main/java/org/runnect/server/common/exception/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/exception/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus {
      * 403 FORBIDDEN
      */
     PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION(HttpStatus.FORBIDDEN, "퍼블릭 코스를 삭제할 권한이 존재하지 않습니다."),
+    PERMISSION_DENIED_RECORD_DELETE_EXCEPTION(HttpStatus.FORBIDDEN, "기록을 삭제할 권한이 존재하지 않습니다."),
 
     /**
      * 404 NOT FOUND

--- a/src/main/java/org/runnect/server/common/exception/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/exception/SuccessStatus.java
@@ -25,6 +25,7 @@ public enum SuccessStatus {
     UPDATE_COURSE_SUCCESS(HttpStatus.OK, "내가 그린 코스 제목 수정 성공"),
     GET_USER_PROFILE_SUCCESS(HttpStatus.OK, "유저 프로필 조회에 성공했습니다."),
     DELETE_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "퍼블릭 코스 삭제에 성공했습니다."),
+    DELETE_RECORD_SUCCESS(HttpStatus.OK, "기록 삭제에 성공했습니다."),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/record/controller/RecordController.java
+++ b/src/main/java/org/runnect/server/record/controller/RecordController.java
@@ -1,19 +1,28 @@
 package org.runnect.server.record.controller;
 
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.exception.SuccessStatus;
 import org.runnect.server.record.dto.request.CreateRecordRequestDto;
+import org.runnect.server.record.dto.request.DeleteRecordsRequestDto;
 import org.runnect.server.record.dto.request.UpdateRecordRequestDto;
-import org.runnect.server.record.dto.response.CreateRecordDto;
 import org.runnect.server.record.dto.response.CreateRecordResponseDto;
+import org.runnect.server.record.dto.response.DeleteRecordsResponseDto;
 import org.runnect.server.record.dto.response.GetRecordResponseDto;
 import org.runnect.server.record.dto.response.UpdateRecordResponseDto;
 import org.runnect.server.record.service.RecordService;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,6 +47,17 @@ public class RecordController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<UpdateRecordResponseDto> updateRecord(@RequestHeader Long userId, @PathVariable(name = "recordId") Long recordId, @RequestBody @Valid final UpdateRecordRequestDto request) {
         return ApiResponseDto.success(SuccessStatus.UPDATE_RECORD_SUCCESS, recordService.updateRecord(userId, recordId, request));
+    }
+
+    @PutMapping("record")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<DeleteRecordsResponseDto> deleteRecords(
+        @RequestHeader Long userId,
+        @Valid @RequestBody DeleteRecordsRequestDto requestDto
+    ) {
+        return ApiResponseDto.success(
+            SuccessStatus.DELETE_RECORD_SUCCESS, recordService.deleteRecords(userId, requestDto)
+        );
     }
 
 }

--- a/src/main/java/org/runnect/server/record/dto/request/DeleteRecordsRequestDto.java
+++ b/src/main/java/org/runnect/server/record/dto/request/DeleteRecordsRequestDto.java
@@ -1,0 +1,17 @@
+package org.runnect.server.record.dto.request;
+
+import java.util.List;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteRecordsRequestDto {
+
+    @Size(min = 1)
+    private List<Long> recordIdList;
+}

--- a/src/main/java/org/runnect/server/record/dto/response/DeleteRecordsResponseDto.java
+++ b/src/main/java/org/runnect/server/record/dto/response/DeleteRecordsResponseDto.java
@@ -1,0 +1,18 @@
+package org.runnect.server.record.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteRecordsResponseDto {
+
+    private Long deletedRecordIdCount;
+
+    public static DeleteRecordsResponseDto from(final Long deletedRecordIdCount) {
+        return new DeleteRecordsResponseDto(deletedRecordIdCount);
+    }
+}

--- a/src/main/java/org/runnect/server/record/repository/RecordRepository.java
+++ b/src/main/java/org/runnect/server/record/repository/RecordRepository.java
@@ -1,5 +1,6 @@
 package org.runnect.server.record.repository;
 
+import java.util.Collection;
 import org.runnect.server.record.entity.Record;
 import org.runnect.server.user.entity.RunnectUser;
 import org.springframework.data.jpa.repository.Query;
@@ -23,5 +24,8 @@ public interface RecordRepository extends Repository<Record, Long> {
 
     long countByRunnectUser(RunnectUser runnectUser);
 
+    List<Record> findByIdIn(Collection<Long> ids);
+
     // DELETE
+    long deleteByIdIn(Collection<Long> ids);
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
#45 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

1. 요청 아이디 리스트를 이용해 삭제할 record list를 가져온다. 이때 둘의 사이즈가 다르면 NotFoundException 발생
2. 가져온 record list를 순회하며 기록 생성 유저와 요청 유저를 비교한다. 이때 다르면 PermissionDeniedException 발생
3. 기록 hard delete

### 🤯 주의할 점이 있나요?

---
기록은 연관된 엔티티도 따로 없고 남겨둬야 할 이유를 딱히 못 찾아서 우선 hard delete로 구현하였습니다.. ! 어떻게 생각하시나용..??
<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
