### PR TITLE
[Feat] getPublicCourseByUser

### DIFF
--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -27,6 +27,7 @@ public enum SuccessStatus {
     DELETE_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "퍼블릭 코스 삭제에 성공했습니다."),
     DELETE_RECORD_SUCCESS(HttpStatus.OK, "기록 삭제에 성공했습니다."),
     UPDATE_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "업로드한 코스 수정 성공"),
+    GET_PUBLIC_COURSE_BY_USER_SUCCESS(HttpStatus.OK,"유저가 업로드한 코스 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/course/entity/Course.java
+++ b/src/main/java/org/runnect/server/course/entity/Course.java
@@ -2,21 +2,15 @@ package org.runnect.server.course.entity;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.LineString;
 import org.runnect.server.common.entity.AuditingTimeEntity;
+import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.record.entity.Record;
 import org.runnect.server.user.entity.RunnectUser;
 
@@ -62,6 +56,9 @@ public class Course extends AuditingTimeEntity {
 
     @Column(nullable = false, columnDefinition = "geometry(LineString, 4326)")
     private LineString path;
+
+    @OneToOne(mappedBy = "course")
+    private PublicCourse publicCourse;
 
     @OneToMany(mappedBy = "course")
     private List<Record> records = new ArrayList<>();

--- a/src/main/java/org/runnect/server/course/repository/CourseRepository.java
+++ b/src/main/java/org/runnect/server/course/repository/CourseRepository.java
@@ -24,6 +24,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("select c from Course c join fetch c.runnectUser where c.runnectUser.id = :userId and c.isPrivate = true and c.deletedAt = null order by c.createdAt desc")
     List<Course> findCourseByUserIdOnlyPrivate(Long userId);
 
+    List<Course> findCoursesByRunnectUserAndIsPrivateIsFalse(RunnectUser runnectUser);
     long countByRunnectUser(RunnectUser runnectUser);
 
     Optional<Course> findById(Long courseId);

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -7,6 +7,7 @@ import org.runnect.server.common.constant.SuccessStatus;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
 import org.runnect.server.publicCourse.dto.request.UpdatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.service.PublicCourseService;
 import org.springframework.http.HttpStatus;
@@ -18,6 +19,19 @@ import org.springframework.web.bind.annotation.*;
 public class PublicCourseController {
 
     private final PublicCourseService publicCourseService;
+
+    @GetMapping("/user")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetPublicCourseByUserResponseDto> getPublicCourseByUser(
+            // TODO : 테스트 후 @UserId final Long userId 로 변경
+            @RequestHeader final Long userId
+    ){
+
+        return ApiResponseDto.success(SuccessStatus.GET_PUBLIC_COURSE_BY_USER_SUCCESS,
+                publicCourseService.getPublicCourseByUser(userId));
+
+    }
+
 
     @PutMapping
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -39,8 +39,9 @@ public class PublicCourseController {
     @GetMapping("/user")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<GetPublicCourseByUserResponseDto> getPublicCourseByUser(
-            // TODO : 테스트 후 @UserId final Long userId 로 변경
-            @RequestHeader final Long userId
+            // TODO : 테스트 후
+            @UserId final Long userId
+            //@RequestHeader final Long userId
     ){
 
         return ApiResponseDto.success(SuccessStatus.GET_PUBLIC_COURSE_BY_USER_SUCCESS,

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/getPublicCourseByUser/GetPublicCourseByUserPublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/getPublicCourseByUser/GetPublicCourseByUserPublicCourse.java
@@ -1,0 +1,40 @@
+package org.runnect.server.publicCourse.dto.response.getPublicCourseByUser;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPublicCourseByUserPublicCourse {
+    private Long id;
+    private Long courseId;
+    private Boolean scrap;
+    private String title;
+    private String image;
+    private GetPublicCourseByUserPublicCourseDeparture departure;
+
+    public static GetPublicCourseByUserPublicCourse of(Long id, Long courseId, Boolean scrap, String title, String image, String region, String city){
+        return new GetPublicCourseByUserPublicCourse(id, courseId, scrap, title, image,
+                GetPublicCourseByUserPublicCourseDeparture.from(region,city));
+
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetPublicCourseByUserPublicCourseDeparture{
+        private String region;
+        private String city;
+
+        public static GetPublicCourseByUserPublicCourseDeparture from(String region, String city) {
+            return new GetPublicCourseByUserPublicCourseDeparture(region, city);
+        }
+    }
+
+
+
+}
+

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/getPublicCourseByUser/GetPublicCourseByUserResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/getPublicCourseByUser/GetPublicCourseByUserResponseDto.java
@@ -1,0 +1,34 @@
+package org.runnect.server.publicCourse.dto.response.getPublicCourseByUser;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPublicCourseByUserResponseDto {
+    private GetPublicCourseByUserUser user;
+    private List<GetPublicCourseByUserPublicCourse> publicCourses;
+
+    public static GetPublicCourseByUserResponseDto of(Long userId,
+                                                      List<GetPublicCourseByUserPublicCourse> publicCourses ) {
+        return new GetPublicCourseByUserResponseDto(GetPublicCourseByUserUser.from(userId), publicCourses);
+
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetPublicCourseByUserUser {
+        private Long id;
+
+        public static GetPublicCourseByUserUser from(Long id) {
+            return new GetPublicCourseByUserUser(id);
+        }
+    }
+}
+

--- a/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
@@ -23,6 +23,7 @@ public class PublicCourse extends AuditingTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private RunnectUser runnectUser;
@@ -37,11 +38,17 @@ public class PublicCourse extends AuditingTimeEntity {
     @Column(nullable = false)
     private String description;
 
-    @OneToMany(mappedBy = "publicCourse")
-    private List<Scrap> scraps = new ArrayList<>();
+    // 아래 코드 주석이유 -> 유저가 현재 스크랩한 코스는 scraptf가 treu인 경우만임
+//    @OneToMany(mappedBy = "publicCourse")
+//    private List<Scrap> scraps = new ArrayList<>();
 
     @OneToMany(mappedBy = "publicCourse")
     private List<Record> records = new ArrayList<>();
+
+    @Transient
+    private Boolean isScrap=false; //현재 사용자가 스크랩한지 아닌지 여부
+
+    public void setIsScrap(Boolean flag){ isScrap=flag;}
 
     @Builder
     public PublicCourse(Course course, RunnectUser user, String title, String description) {

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -1,16 +1,22 @@
 package org.runnect.server.publicCourse.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.exception.NotFoundException;
 import org.runnect.server.common.exception.PermissionDeniedException;
+import org.runnect.server.course.entity.Course;
+import org.runnect.server.course.repository.CourseRepository;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
+import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserPublicCourse;
+import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.publicCourse.repository.PublicCourseRepository;
 import org.runnect.server.record.entity.Record;
+import org.runnect.server.scrap.entity.Scrap;
 import org.runnect.server.scrap.repository.ScrapRepository;
 import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
@@ -25,6 +31,47 @@ public class PublicCourseService {
     private final PublicCourseRepository publicCourseRepository;
     private final UserRepository userRepository;
     private final ScrapRepository scrapRepository;
+    private final CourseRepository courseRepository;
+
+
+    public GetPublicCourseByUserResponseDto getPublicCourseByUser(Long userId){
+        List<GetPublicCourseByUserPublicCourse> getPublicCourseByUserPublicCourses = new ArrayList<>();
+
+        //1. 받은 userId가 유저가 존재하는지 확인
+        RunnectUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
+                        ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        //2. userId에 연결된 course중 private이 false인 코스만 가져오기
+        List<Course> courses = courseRepository.findCoursesByRunnectUserAndIsPrivateIsFalse(user);
+
+        //3. 유저가 스크랩한 코스들 가져오기
+        List<Scrap> scraps = scrapRepository.findAllByUserIdAndScrapTF(userId).get();
+
+        courses.forEach(course->{
+            PublicCourse publicCourse = course.getPublicCourse();
+
+            //4. 각 코스들의 publicCourse와 scrap 여부 파악
+            scraps.forEach(scrap->
+                    publicCourse.setIsScrap(scrap.getPublicCourse().equals(publicCourse)));
+
+            //5. responseDto 만듬
+            getPublicCourseByUserPublicCourses.add(
+                    GetPublicCourseByUserPublicCourse.of(
+                            publicCourse.getId(),
+                            course.getId(),
+                            publicCourse.getIsScrap(),
+                            publicCourse.getTitle(),
+                            course.getImage(),
+                            course.getDepartureRegion(),
+                            course.getDepartureCity()));
+        });
+
+
+
+        return GetPublicCourseByUserResponseDto.of(userId, getPublicCourseByUserPublicCourses);
+    }
+
 
     @Transactional
     public DeletePublicCoursesResponseDto deletePublicCourses(

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -10,8 +10,6 @@ import org.runnect.server.common.exception.NotFoundException;
 import org.runnect.server.common.exception.PermissionDeniedException;
 import org.runnect.server.course.entity.Course;
 import org.runnect.server.course.repository.CourseRepository;
-import org.runnect.server.course.entity.Course;
-import org.runnect.server.course.repository.CourseRepository;
 import org.runnect.server.publicCourse.dto.request.CreatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -8,6 +8,7 @@ import org.runnect.server.scrap.entity.Scrap;
 import org.runnect.server.user.entity.RunnectUser;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface ScrapRepository extends Repository<Scrap, Long> {
     // CREATE
@@ -18,7 +19,7 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
     Optional<Scrap> findByUserIdAndPublicCourseId(Long userId, Long publicCourseId);
 
     @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse pc JOIN FETCH pc.course c WHERE s.runnectUser.id = :userId AND s.scrapTF = true")
-    Optional<List<Scrap>> findAllByUserIdAndScrapTF(Long userId);
+    Optional<List<Scrap>> findAllByUserIdAndScrapTF(@Param("userId") Long userId);
 
     long countByRunnectUser(RunnectUser runnectUser);
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #60 

### 🤔 어떻게 이슈를 해결했나요?

---

- request, response dto 생성
//1. 받은 userId가 유저가 존재하는지 확인
//2. userId에 연결된 course중 private이 false인 코스만 가져오기
 //3. 유저가 스크랩한 코스들 가져오기
//4. 각 코스들의 publicCourse와 scrap 여부 파악
- 이때 PublicCourse entity에 @Transient   isScrap 필드를 두어 일시적으로 현재사용자가 스크랩했는지 여부를 저장



### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
