### PR TITLE
[Feat] social login(Apple)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	// hibernate-spatial
 	implementation 'org.hibernate:hibernate-spatial:5.6.11.Final'
 
+	//json parser
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.12'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/runnect/server/auth/controller/AuthController.java
+++ b/src/main/java/org/runnect/server/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotBlank;
 
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.auth.dto.request.SignInRequestDto;
+import org.runnect.server.auth.dto.response.AuthResponseDto;
 import org.runnect.server.auth.dto.response.GetNewTokenResponseDto;
 import org.runnect.server.auth.dto.response.SignInResponseDto;
 import org.runnect.server.auth.service.AuthService;
@@ -24,8 +25,14 @@ public class AuthController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponseDto<SignInResponseDto> signIn(@Valid @RequestBody SignInRequestDto requestDto) {
-        return ApiResponseDto.success(SuccessStatus.LOGIN_SUCCESS, authService.signIn(requestDto));
+    public ApiResponseDto<AuthResponseDto> signIn(@Valid @RequestBody SignInRequestDto requestDto) {
+        AuthResponseDto result = authService.signIn(requestDto);
+        if(result.getClass().equals(SignInResponseDto.class)){
+            return ApiResponseDto.success(SuccessStatus.LOGIN_SUCCESS, result);
+        }
+        else{
+            return ApiResponseDto.success(SuccessStatus.SIGNUP_SUCCESS, result);
+        }
     }
 
     @GetMapping("/getNewToken")

--- a/src/main/java/org/runnect/server/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/org/runnect/server/auth/dto/response/AuthResponseDto.java
@@ -1,0 +1,4 @@
+package org.runnect.server.auth.dto.response;
+
+public interface AuthResponseDto {
+}

--- a/src/main/java/org/runnect/server/auth/dto/response/SignUpResponseDto.java
+++ b/src/main/java/org/runnect/server/auth/dto/response/SignUpResponseDto.java
@@ -5,18 +5,20 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class SignInResponseDto implements AuthResponseDto{
+public class SignUpResponseDto implements AuthResponseDto{
 
     private String type;
     private String email;
+    private String nickname;
     private String accessToken;
     private String refreshToken;
 
-    public static SignInResponseDto of(final String type, final String email,
-        final String accessToken, final String refreshToken) {
-        return new SignInResponseDto(type, email, accessToken, refreshToken);
+    public static SignUpResponseDto of(final String type, final String email, final String nickname,
+                                       final String accessToken, final String refreshToken) {
+        return new SignUpResponseDto(type, email, nickname, accessToken, refreshToken);
     }
 }

--- a/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
+++ b/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
@@ -1,8 +1,6 @@
 package org.runnect.server.auth.service;
 
 
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.JWTClaimsSet;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.auth.dto.response.SocialInfoResponseDto;
@@ -10,98 +8,77 @@ import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-
-import com.nimbusds.jose.*;
-import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
-import java.net.URL;
-import com.nimbusds.jose.jwk.RSAKey;
-import java.security.interfaces.RSAPublicKey;
 
-
+import java.text.ParseException;
 
 
 @Service
 @RequiredArgsConstructor
 public class AppleSignInService {
-    @Value("${apple.key_id}")
+    @Value("${apple.key-id}")
     private String APPLE_KEY_ID;
 
-    @Value("${apple.team_id}")
+    @Value("${apple.team-id}")
     private String APPLE_TEAM_ID;
 
-    @Value("${apple.bundle_id}")
+    @Value("${apple.bundle-id}")
     private String APPLE_BUNDLE_ID;
 
-    @Value("${apple.auth_url}")
-    private String APPLE_AUTH_URL;
 
-
+    @Value("${apple.issue-url}")
+    private String APPLE_ISSUE_URL;
 
     public SocialInfoResponseDto getSocialInfo(String idToken) {
-        try{
-            // 클라에서 준 인증토큰이 정말 애플에서 발급받은게 맞는지 확인
 
+
+        // 클라에서 준 인증토큰이 정말 애플에서 발급받은게 맞는지 확인
+
+        try{
             //1. idToken을 parse
             SignedJWT jwt = SignedJWT.parse(idToken);
-            JWSHeader header = jwt.getHeader();
-            String kid = header.getKeyID();
+            JWTClaimsSet claimsSet = jwt.getJWTClaimsSet();
 
+            // 발급처, aud, 시간제한, 이메일 검증
 
-            // apple api를 통해 공개키 3개를 받아온다.
-            URL jwkSetURL = new URL(APPLE_AUTH_URL);
-            JWKSet jwkSet = JWKSet.load(jwkSetURL);
-            //그 중 kid와 동일한 공개키 사용
-            JWK jwk = jwkSet.getKeyByKeyId(kid);
-
-
-            //클라이언트로부터 받은 identity token을 decode한다.
-
-
-            // Convert the JWK to an RSAKey
-            RSAKey rsaKey = (RSAKey) jwk;
-            RSAPublicKey publicKey = rsaKey.toRSAPublicKey();
-            RSASSAVerifier verifier = new RSASSAVerifier(publicKey);
-
-            if (!jwt.verify(verifier)) {
-                new Exception();
+            //만료된경우
+            if (System.currentTimeMillis() < claimsSet.getExpirationTime().getTime()) {
+                throw new UnauthorizedException(ErrorStatus.APPLE_ID_TOKEN_TIME_EXPIRED_EXCEPTION,
+                        ErrorStatus.APPLE_ID_TOKEN_TIME_EXPIRED_EXCEPTION.getMessage());
             }
 
+            // 발급처, aud,이메일 검증 실패시
+            if (!claimsSet.getIssuer().equals(APPLE_ISSUE_URL) ||
+                    !claimsSet.getAudience().get(0).equals(APPLE_BUNDLE_ID) ||
+                    !Boolean.parseBoolean(claimsSet.getStringClaim("email_verified"))) {
+                throw new UnauthorizedException(ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION,
+                        ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION.getMessage());
 
-            // Verify claims (issuer, audience, expiration, etc.)
-            JWTClaimsSet claimsSet = jwt.getJWTClaimsSet();
-            System.out.println(claimsSet.getSubject());
-            System.out.println(claimsSet.getStringClaim("email"));
+            }
 
-            return null;
-//        if (!"https://appleid.apple.com".equals(claimsSet.getIssuer()) ||
-//                "your-client-id".equals(claimsSet.getAudience()) ||
-//                System.currentTimeMillis() > claimsSet.getExpirationTime().getTime()) {
-//            return false;
-//        }
-//
-//        // 인증토큰 decoded
-//        String subject = claimsSet.getSubject();
-//        String email = claimsSet.getStringClaim("email");
+            return SocialInfoResponseDto.of(claimsSet.getStringClaim("email"), claimsSet.getSubject());
 
-
-        }catch (Exception e){
-            new UnauthorizedException(ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION,
+        }catch (ParseException e){
+            throw new UnauthorizedException(ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION,
                     ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION.getMessage());
-
-
         }
 
-
-
-        return null;
-
     }
 
-    public static void main(String[] args) {
-        AppleSignInService appleSignInService = new AppleSignInService();
-        appleSignInService.getSocialInfo("");
-    }
+//       id_token 형태 :
+//       {
+//       "aud": 번들아이디,
+//       "sub": 애플 유니크 소셜아이디,
+//       "c_hash":"",
+//       "nonce_supported":true,
+//       "email_verified":"true",
+//       "auth_time":1699270438,
+//       "iss":"https:\/\/appleid.apple.com",
+//       "is_private_email":"true",
+//       "exp":1699356838,
+//       "iat":1699270438,
+//       "email":이메일
+//       }
+
 
 }

--- a/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
+++ b/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
@@ -1,2 +1,107 @@
-package org.runnect.server.auth.service;public class AppleSignInService {
+package org.runnect.server.auth.service;
+
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWTClaimsSet;
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.auth.dto.response.SocialInfoResponseDto;
+import org.runnect.server.common.constant.ErrorStatus;
+import org.runnect.server.common.exception.UnauthorizedException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import java.net.URL;
+import com.nimbusds.jose.jwk.RSAKey;
+import java.security.interfaces.RSAPublicKey;
+
+
+
+
+@Service
+@RequiredArgsConstructor
+public class AppleSignInService {
+    @Value("${apple.key_id}")
+    private String APPLE_KEY_ID;
+
+    @Value("${apple.team_id}")
+    private String APPLE_TEAM_ID;
+
+    @Value("${apple.bundle_id}")
+    private String APPLE_BUNDLE_ID;
+
+    @Value("${apple.auth_url}")
+    private String APPLE_AUTH_URL;
+
+
+
+    public SocialInfoResponseDto getSocialInfo(String idToken) {
+        try{
+            // 클라에서 준 인증토큰이 정말 애플에서 발급받은게 맞는지 확인
+
+            //1. idToken을 parse
+            SignedJWT jwt = SignedJWT.parse(idToken);
+            JWSHeader header = jwt.getHeader();
+            String kid = header.getKeyID();
+
+
+            // apple api를 통해 공개키 3개를 받아온다.
+            URL jwkSetURL = new URL(APPLE_AUTH_URL);
+            JWKSet jwkSet = JWKSet.load(jwkSetURL);
+            //그 중 kid와 동일한 공개키 사용
+            JWK jwk = jwkSet.getKeyByKeyId(kid);
+
+
+            //클라이언트로부터 받은 identity token을 decode한다.
+
+
+            // Convert the JWK to an RSAKey
+            RSAKey rsaKey = (RSAKey) jwk;
+            RSAPublicKey publicKey = rsaKey.toRSAPublicKey();
+            RSASSAVerifier verifier = new RSASSAVerifier(publicKey);
+
+            if (!jwt.verify(verifier)) {
+                new Exception();
+            }
+
+
+            // Verify claims (issuer, audience, expiration, etc.)
+            JWTClaimsSet claimsSet = jwt.getJWTClaimsSet();
+            System.out.println(claimsSet.getSubject());
+            System.out.println(claimsSet.getStringClaim("email"));
+
+            return null;
+//        if (!"https://appleid.apple.com".equals(claimsSet.getIssuer()) ||
+//                "your-client-id".equals(claimsSet.getAudience()) ||
+//                System.currentTimeMillis() > claimsSet.getExpirationTime().getTime()) {
+//            return false;
+//        }
+//
+//        // 인증토큰 decoded
+//        String subject = claimsSet.getSubject();
+//        String email = claimsSet.getStringClaim("email");
+
+
+        }catch (Exception e){
+            new UnauthorizedException(ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION,
+                    ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION.getMessage());
+
+
+        }
+
+
+
+        return null;
+
+    }
+
+    public static void main(String[] args) {
+        AppleSignInService appleSignInService = new AppleSignInService();
+        appleSignInService.getSocialInfo("");
+    }
+
 }

--- a/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
+++ b/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
@@ -1,0 +1,2 @@
+package org.runnect.server.auth.service;public class AppleSignInService {
+}

--- a/src/main/java/org/runnect/server/auth/service/AuthService.java
+++ b/src/main/java/org/runnect/server/auth/service/AuthService.java
@@ -26,6 +26,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final GoogleSignInService googleSignInService;
+    private final AppleSignInService appleSignInService;
     private final JwtService jwtService;
     private final RedisService redisService;
 
@@ -106,7 +107,15 @@ public class AuthService {
         switch (socialType) {
             case GOOGLE:
                 socialInfoResponseDto = googleSignInService.getSocialInfo(socialAccessToken);
+                break;
+            case APPLE:
+                socialInfoResponseDto = appleSignInService.getSocialInfo(socialAccessToken);
+                break;
+            case KAKAO:
+                //카카오 소셜정보 해독
+                break;
         }
+
         return socialInfoResponseDto;
     }
 

--- a/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus {
     INVALID_REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
     INVALID_GOOGLE_ID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 구글 아이디 토큰입니다."),
+    INVALID_APPLE_ID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED,"유효하지 않은 애플 아이디 토큰입니다."),
 
     /**
      * 403 FORBIDDEN

--- a/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus {
     INVALID_ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
     INVALID_GOOGLE_ID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 구글 아이디 토큰입니다."),
     INVALID_APPLE_ID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED,"유효하지 않은 애플 아이디 토큰입니다."),
+    APPLE_ID_TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED,"만료된 애플 아이디 토큰입니다."),
 
     /**
      * 403 FORBIDDEN


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #70 

### 🤔 어떻게 이슈를 해결했나요?

---

- idToken을 파싱해서 
- 발급처, 번들, 인증된 이메일인지, 시간제한내인지 검사
- db에 존재하는지 아닌지에 따라 회원가입, 로그인 분기처리

### 🤯 주의할 점이 있나요?

---
AuthResponse 인터페이스를 만들어 signIn 메소드의 Response로 회원가입response, 로그인 response가 올수 있게함
<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
