### PR TITLE
[Feat] getPublicCourseDetail 

### DIFF
--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -16,7 +16,7 @@ public enum SuccessStatus {
     CREATE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 성공"),
     DELETE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 취소 성공"),
     READ_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 조회 성공"),
-    GET_COURSE_LIST_BY_USER(HttpStatus.OK, "내가 그린 코스 리스트 조회에 성공했습니다."),
+    GET_COURSE_LIST_BY_USER_SUCCESS(HttpStatus.OK, "내가 그린 코스 리스트 조회에 성공했습니다."),
     GET_SCRAP_COURSE_BY_USER_SUCCESS(HttpStatus.OK, "스크랩한 코스 조회 성공"),
     UPDATE_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 수정 성공"),
     GET_COURSE_DETAIL_SUCCESS(HttpStatus.OK, "코스 상세 조회에 성공했습니다."),
@@ -29,6 +29,7 @@ public enum SuccessStatus {
     UPDATE_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "업로드한 코스 수정 성공"),
     DELETE_COURSES_SUCCESS(HttpStatus.OK, "코스 삭제 성공"),
     GET_USER_STAMPS_SUCCESS(HttpStatus.OK, "유저 스탬프 조회 성공"),
+    GET_PUBLIC_COURSE_DETAIL_SUCCESS(HttpStatus.OK,"업로드 코스 상세 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/course/controller/CourseController.java
+++ b/src/main/java/org/runnect/server/course/controller/CourseController.java
@@ -57,7 +57,7 @@ public class CourseController {
     @GetMapping("/user")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<CourseGetByUserResponseDto> getCourseByUser(@RequestHeader Long userId) {
-        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER,
+        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER_SUCCESS,
             courseService.getCourseByUser(userId));
     }
 
@@ -65,7 +65,7 @@ public class CourseController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<CourseGetByUserResponseDto> getPrivateCourseByUser(
         @RequestHeader Long userId) {
-        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER,
+        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER_SUCCESS,
             courseService.getPrivateCourseByUser(userId));
     }
 

--- a/src/main/java/org/runnect/server/course/repository/CourseRepository.java
+++ b/src/main/java/org/runnect/server/course/repository/CourseRepository.java
@@ -17,13 +17,13 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     // READ
     @Query("select c from Course c join fetch c.runnectUser where c.runnectUser.id = :userId and c.deletedAt = null order by c.createdAt desc")
-    List<Course> findCourseByUserId(Long userId);
+    List<Course> findCourseByUserId(@Param("userId") Long userId);
 
     @Query("select c from Course c join fetch c.runnectUser where c.id = :courseId")
-    Optional<Course> findCourseByIdFetchUser(Long courseId);
+    Optional<Course> findCourseByIdFetchUser(@Param("courseId") Long courseId);
 
     @Query("select c from Course c join fetch c.runnectUser where c.runnectUser.id = :userId and c.isPrivate = true and c.deletedAt = null order by c.createdAt desc")
-    List<Course> findCourseByUserIdOnlyPrivate(Long userId);
+    List<Course> findCourseByUserIdOnlyPrivate(@Param("userId") Long userId);
 
     List<Course> findCoursesByRunnectUserAndIsPrivateIsFalse(RunnectUser runnectUser);
     long countByRunnectUser(RunnectUser runnectUser);

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -10,6 +10,7 @@ import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto
 import org.runnect.server.publicCourse.dto.request.UpdatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.dto.response.GetPublicCourseDetailResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.service.PublicCourseService;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,17 @@ public class PublicCourseController {
     ){
 
         return ApiResponseDto.success(SuccessStatus.CREATE_PUBLIC_COURSE_SUCCESS, publicCourseService.createPublicCourse(userId, createPublicCourseRequestDto));
+
+    }
+
+    @GetMapping("/detail/{publicCourseId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetPublicCourseDetailResponseDto> getPublicCourseDetail(
+            @UserId final Long userId,
+            @PathVariable final Long publicCourseId
+    ){
+
+        return ApiResponseDto.success(SuccessStatus.GET_PUBLIC_COURSE_DETAIL_SUCCESS, publicCourseService.getPublicCourseDetail(userId, publicCourseId));
 
     }
 

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/GetPublicCourseDetailResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/GetPublicCourseDetailResponseDto.java
@@ -1,0 +1,94 @@
+package org.runnect.server.publicCourse.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPublicCourseDetailResponseDto {
+    private GetPublicCourseDetailUser user;
+    private GetPublicCourseDetailPublicCourse publicCourse;
+
+    public static GetPublicCourseDetailResponseDto of(String nickname, int level, String userImage, Boolean isNowUser,
+                                                      Long publicCourseId, Long courseId, Boolean isScrap, Long scrapCount,
+                                                      String courseImage, String title, String description, List<List<Double>> path,
+                                                      Float distance, String region, String city, String town, String name) {
+        return new GetPublicCourseDetailResponseDto(
+                GetPublicCourseDetailResponseDto.GetPublicCourseDetailUser.from(nickname, level, userImage, isNowUser),
+                GetPublicCourseDetailResponseDto.GetPublicCourseDetailPublicCourse.from(publicCourseId, courseId, isScrap, scrapCount, courseImage, title, description, path, distance, region, city, town, name));
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetPublicCourseDetailUser {
+        private String nickname;
+        private int level;
+        private String image;
+        private Boolean isNowUser;
+
+        public static GetPublicCourseDetailResponseDto.GetPublicCourseDetailUser from(String nickname, int level,
+                                                                                      String image, Boolean isNowUser) {
+            return new GetPublicCourseDetailResponseDto.GetPublicCourseDetailUser(nickname, level, image, isNowUser);
+        }
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetPublicCourseDetailPublicCourse {
+        private Long id;
+        private Long courseId;
+        private Boolean isScrap;
+        private Long scrapCount;
+        private String image;
+        private String title;
+        private String description;
+        private List<List<Double>> path;
+        private Float distance;
+        private GetPublicCourseDetailPublicCourseDeparture departure;
+
+        public static GetPublicCourseDetailResponseDto.GetPublicCourseDetailPublicCourse from(Long publicCourseId, Long courseId,
+                                                                                              Boolean isScrap, Long scrapCount,
+                                                                                              String courseImage, String title,
+                                                                                              String description, List<List<Double>> path,
+                                                                                              Float distance, String region,
+                                                                                              String city, String town, String name) {
+            return new GetPublicCourseDetailResponseDto
+                    .GetPublicCourseDetailPublicCourse(publicCourseId, courseId, isScrap, scrapCount,
+                    courseImage, title, description, path, distance,
+                    GetPublicCourseDetailResponseDto.GetPublicCourseDetailPublicCourse
+                    .GetPublicCourseDetailPublicCourseDeparture.from(region, city, town, name));
+        }
+
+
+        @Getter
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        @AllArgsConstructor(access = AccessLevel.PRIVATE)
+        public static class GetPublicCourseDetailPublicCourseDeparture {
+            private String region;
+            private String city;
+            private String town;
+            private String name;
+
+            public static GetPublicCourseDetailResponseDto
+                    .GetPublicCourseDetailPublicCourse
+                    .GetPublicCourseDetailPublicCourseDeparture from(String region, String city,
+                                                                     String town, String name) {
+                return new GetPublicCourseDetailResponseDto
+                        .GetPublicCourseDetailPublicCourse
+                        .GetPublicCourseDetailPublicCourseDeparture(region, city, town, name);
+            }
+        }
+    }
+}
+
+

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -7,19 +7,20 @@ import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.user.entity.RunnectUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Long> {
     // CREATE
 
     // READ
     @Query("SELECT pc FROM PublicCourse pc JOIN FETCH pc.course WHERE pc.id = :publicCourseId")
-    Optional<PublicCourse> findById(Long publicCourseId);
+    Optional<PublicCourse> findById(@Param("publicCourseId") Long publicCourseId);
 
     @Query("select count(pc.id) from PublicCourse pc where pc.runnectUser = :user")
-    Long countPublicCourseByUser(RunnectUser user);
+    Long countPublicCourseByUser(@Param("user") RunnectUser user);
 
     @Query("select pc from PublicCourse pc join fetch pc.course where pc.runnectUser = :user")
-    List<PublicCourse> findPublicCoursesByRunnectUser(RunnectUser user);
+    List<PublicCourse> findPublicCoursesByRunnectUser(@Param("user") RunnectUser user);
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
 

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -7,12 +7,14 @@ import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.exception.ConflictException;
 import org.runnect.server.common.exception.NotFoundException;
 import org.runnect.server.common.exception.PermissionDeniedException;
+import org.runnect.server.course.dto.response.GetCourseDetailResponseDto;
 import org.runnect.server.course.entity.Course;
 import org.runnect.server.course.repository.CourseRepository;
 import org.runnect.server.publicCourse.dto.request.CreatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.dto.response.GetPublicCourseDetailResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.publicCourse.repository.PublicCourseRepository;
@@ -32,6 +34,29 @@ public class PublicCourseService {
     private final UserRepository userRepository;
     private final ScrapRepository scrapRepository;
     private final CourseRepository courseRepository;
+
+    public GetPublicCourseDetailResponseDto getPublicCourseDetail(final Long userId, final Long publicCourseId){
+        //0. 유저가 존재하는지
+        RunnectUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
+                        ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        //1. publicCourse가 존재하는지
+        PublicCourse publicCourse = publicCourseRepository.findById(publicCourseId).orElseThrow(()->new NotFoundException(ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION,
+                ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION.getMessage()));
+
+        //2. 이미 삭제된 코스인지
+        if(publicCourse.getCourse().getDeletedAt()==null){
+            new NotFoundException(ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION,
+                    ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION.getMessage());
+        }
+
+        return GetPublicCourseDetailResponseDto.of(user.getNickname(),user.getLevel(),user.getLatestStamp().name(),publicCourse.getCourse().getRunnectUser().equals(user),
+                publicCourse.getId(), publicCourse.getCourse().getId(),)
+
+
+
+    }
 
     @Transactional
     public CreatePublicCourseResponseDto createPublicCourse(

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -28,4 +28,5 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
     // DELETE
     Long deleteByPublicCourseIn(Collection<PublicCourse> publicCourses);
 
+    Long countByPublicCourseAndScrapTFIsTrue(PublicCourse publicCourse);
 }

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -16,7 +16,7 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
 
     // READ
     @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse WHERE s.runnectUser.id = :userId AND s.publicCourse.id = :publicCourseId")
-    Optional<Scrap> findByUserIdAndPublicCourseId(Long userId, Long publicCourseId);
+    Optional<Scrap> findByUserIdAndPublicCourseId(@Param("userId") Long userId, @Param("publicCourseId") Long publicCourseId);
 
     @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse pc JOIN FETCH pc.course c WHERE s.runnectUser.id = :userId AND s.scrapTF = true")
     Optional<List<Scrap>> findAllByUserIdAndScrapTF(@Param("userId") Long userId);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #71 

### 🤔 어떻게 이슈를 해결했나요?

---

- dto 작성
- 서비스 로직에서 dto에 맞게 자료를 넣음.



### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->

고민중인 사항 : get의 response dto에는 많은 데이터들을 포함하게됨.
그러나 그렇다고 entity를 responseDto에 넣으면 영속성 문제 발생 및 결속력이 강화됨.
그렇다고 primitive 값을 그대로 노출하니 dto의 인자가 너무 많아짐.
어떻게 할지 고민중에 있습니다.
