### PR TITLE
[Feat] recommendPublicCourse

### DIFF
--- a/src/main/java/org/runnect/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/org/runnect/server/common/advice/ControllerExceptionAdvice.java
@@ -50,10 +50,18 @@ public class ControllerExceptionAdvice {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ApiResponseDto handleConstraintViolationException(final IllegalArgumentException e) {
+        return ApiResponseDto.error(ErrorStatus.VALIDATION_REQUEST_HEADER_MISSING_EXCEPTION, String.format("%s. (%s)", ErrorStatus.INVALID_PARAMETER_EXCEPTION.getMessage(), e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MissingServletRequestParameterException.class)
     protected ApiResponseDto handleMissingRequestParameterException(final MissingServletRequestParameterException e) {
         return ApiResponseDto.error(ErrorStatus.VALIDATION_REQUEST_PARAMETER_MISSING_EXCEPTION, String.format("%s. (%s)", ErrorStatus.VALIDATION_REQUEST_PARAMETER_MISSING_EXCEPTION.getMessage(), e.getParameterName()));
     }
+
+
 
     /**
      * 500 Internal Server Error

--- a/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus {
     NOT_FOUND_RECORD_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 레코드 아이디입니다."),
     NOT_FOUND_PUBLIC_COURSE_EXCEPTION(HttpStatus.BAD_REQUEST,"유효하지 않은 퍼블릭 코스 아이디입니다."),
     UNMATCHED_COURSE_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인된 유저가 그린 코스가 아닙니다."),
+    INVALID_SORT_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "sort 파라미터에 올바른 값이 입력되지 않았습니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus {
     NOT_FOUND_PUBLIC_COURSE_EXCEPTION(HttpStatus.BAD_REQUEST,"유효하지 않은 퍼블릭 코스 아이디입니다."),
     UNMATCHED_COURSE_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인된 유저가 그린 코스가 아닙니다."),
     INVALID_SORT_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "sort 파라미터에 올바른 값이 입력되지 않았습니다."),
+    INVALID_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "파라미터에 올바른 값이 입력되지 않았습니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/org/runnect/server/common/constant/SortStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SortStatus.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SortStatus {
-    SCRAP_DESC("scrap"),
-    DATE_DESC("date");
+    SCRAP_DESC("scrap","scrapCount"),
+    DATE_DESC("date","createdAt");
+
     private final String vlaue;
+    private final String property;
 }

--- a/src/main/java/org/runnect/server/common/constant/SortStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SortStatus.java
@@ -1,0 +1,14 @@
+package org.runnect.server.common.constant;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SortStatus {
+    SCRAP_DESC("scrap"),
+    DATE_DESC("date");
+    private final String vlaue;
+}

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -16,7 +16,7 @@ public enum SuccessStatus {
     CREATE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 성공"),
     DELETE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 취소 성공"),
     READ_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 조회 성공"),
-    GET_COURSE_LIST_BY_USER(HttpStatus.OK, "내가 그린 코스 리스트 조회에 성공했습니다."),
+    GET_COURSE_LIST_BY_USER_SUCCESS(HttpStatus.OK, "내가 그린 코스 리스트 조회에 성공했습니다."),
     GET_SCRAP_COURSE_BY_USER_SUCCESS(HttpStatus.OK, "스크랩한 코스 조회 성공"),
     UPDATE_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 수정 성공"),
     GET_COURSE_DETAIL_SUCCESS(HttpStatus.OK, "코스 상세 조회에 성공했습니다."),
@@ -29,6 +29,7 @@ public enum SuccessStatus {
     UPDATE_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "업로드한 코스 수정 성공"),
     DELETE_COURSES_SUCCESS(HttpStatus.OK, "코스 삭제 성공"),
     GET_USER_STAMPS_SUCCESS(HttpStatus.OK, "유저 스탬프 조회 성공"),
+    GET_PUBLIC_COURSE_DETAIL_SUCCESS(HttpStatus.OK,"업로드 코스 상세 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -30,6 +30,7 @@ public enum SuccessStatus {
     GET_PUBLIC_COURSE_BY_USER_SUCCESS(HttpStatus.OK,"유저가 업로드한 코스 조회 성공"),
     DELETE_COURSES_SUCCESS(HttpStatus.OK, "코스 삭제 성공"),
     GET_USER_STAMPS_SUCCESS(HttpStatus.OK, "유저 스탬프 조회 성공"),
+    GET_RECOMMENDED_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "추천 코스 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -30,6 +30,7 @@ public enum SuccessStatus {
     GET_PUBLIC_COURSE_BY_USER_SUCCESS(HttpStatus.OK,"유저가 업로드한 코스 조회 성공"),
     DELETE_COURSES_SUCCESS(HttpStatus.OK, "코스 삭제 성공"),
     GET_USER_STAMPS_SUCCESS(HttpStatus.OK, "유저 스탬프 조회 성공"),
+    SEARCH_PUBLIC_COURSE_SUCCESS(HttpStatus.OK,"업로드된 코스 검색 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -16,7 +16,7 @@ public enum SuccessStatus {
     CREATE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 성공"),
     DELETE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 취소 성공"),
     GET_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 조회 성공"),
-    GET_COURSE_LIST_BY_USER(HttpStatus.OK, "내가 그린 코스 리스트 조회에 성공했습니다."),
+    GET_COURSE_LIST_BY_USER_SUCCESS(HttpStatus.OK, "내가 그린 코스 리스트 조회에 성공했습니다."),
     GET_SCRAP_COURSE_BY_USER_SUCCESS(HttpStatus.OK, "스크랩한 코스 조회 성공"),
     UPDATE_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 수정 성공"),
     GET_COURSE_DETAIL_SUCCESS(HttpStatus.OK, "코스 상세 조회에 성공했습니다."),
@@ -32,6 +32,7 @@ public enum SuccessStatus {
     GET_USER_STAMPS_SUCCESS(HttpStatus.OK, "유저 스탬프 조회 성공"),
     GET_RECOMMENDED_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "추천 코스 조회 성공"),
     SEARCH_PUBLIC_COURSE_SUCCESS(HttpStatus.OK,"업로드된 코스 검색 성공"),
+    GET_PUBLIC_COURSE_DETAIL_SUCCESS(HttpStatus.OK,"업로드 코스 상세 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -15,7 +15,7 @@ public enum SuccessStatus {
     NEW_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공했습니다."),
     CREATE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 성공"),
     DELETE_SCRAP_SUCCESS(HttpStatus.OK, "코스 스크랩 취소 성공"),
-    READ_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 조회 성공"),
+    GET_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 조회 성공"),
     GET_COURSE_LIST_BY_USER(HttpStatus.OK, "내가 그린 코스 리스트 조회에 성공했습니다."),
     GET_SCRAP_COURSE_BY_USER_SUCCESS(HttpStatus.OK, "스크랩한 코스 조회 성공"),
     UPDATE_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 수정 성공"),

--- a/src/main/java/org/runnect/server/common/resolver/WebConfig.java
+++ b/src/main/java/org/runnect/server/common/resolver/WebConfig.java
@@ -2,6 +2,7 @@ package org.runnect.server.common.resolver;
 
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.resolver.userId.UserIdResolver;
+import org.runnect.server.common.resolver.sort.SortStatusIdResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -13,9 +14,12 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final UserIdResolver userIdxResolver;
+    private final SortStatusIdResolver sortStatusIdResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+
         resolvers.add(userIdxResolver);
+        resolvers.add(sortStatusIdResolver);
     }
 }

--- a/src/main/java/org/runnect/server/common/resolver/sort/SortStatusId.java
+++ b/src/main/java/org/runnect/server/common/resolver/sort/SortStatusId.java
@@ -1,0 +1,11 @@
+package org.runnect.server.common.resolver.sort;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SortStatusId {
+}

--- a/src/main/java/org/runnect/server/common/resolver/sort/SortStatusIdResolver.java
+++ b/src/main/java/org/runnect/server/common/resolver/sort/SortStatusIdResolver.java
@@ -1,0 +1,76 @@
+package org.runnect.server.common.resolver.sort;
+
+
+import org.runnect.server.common.constant.SortStatus;
+import org.runnect.server.common.constant.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.common.exception.BadRequestException;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class SortStatusIdResolver implements HandlerMethodArgumentResolver{
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(SortStatusId.class) && String.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String queryString = request.getQueryString();
+        Map<String, List<String>> splitQuery = Util.splitQuery(queryString);
+
+
+        if(!splitQuery.containsKey("sort") || splitQuery.get("sort").get(0)==null){
+            // 1번째 조건 : ~url~/public-course
+            // 2번째 조건 : ~url~/public-course?sort=
+            //정렬할 기준(미입력시 자동으로 최신순)
+            return "date";
+        }
+
+        if(!Arrays.stream(SortStatus.values())
+                .map(sortStatus -> sortStatus.getVlaue())
+                .collect(Collectors.toList())
+                .contains(splitQuery.get("sort").get(0))){
+            throw new BadRequestException(ErrorStatus.INVALID_SORT_PARAMETER_EXCEPTION,ErrorStatus.INVALID_SORT_PARAMETER_EXCEPTION.getMessage());
+        }
+
+        return splitQuery.get("sort").get(0);
+
+
+    }
+
+
+    static class Util {
+        public static Map<String, List<String>> splitQuery(String query_string) {
+            final Map<String, List<String>> query_pairs = new LinkedHashMap<String, List<String>>();
+            final String[] pairs = query_string.split("&");
+            try {
+                for (String pair : pairs) {
+                    final int idx = pair.indexOf("=");
+                    String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
+                    if (!query_pairs.containsKey(key)) query_pairs.put(key, new LinkedList<String>());
+                    final String value = idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8") : null;
+                    query_pairs.get(key).add(value);
+                }
+                return query_pairs;
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/runnect/server/common/resolver/userId/UserIdResolver.java
+++ b/src/main/java/org/runnect/server/common/resolver/userId/UserIdResolver.java
@@ -1,7 +1,6 @@
 package org.runnect.server.common.resolver.userId;
 
 import org.runnect.server.common.constant.TokenStatus;
-import org.runnect.server.common.exception.BasicException;
 import org.runnect.server.common.constant.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.user.exception.authException.InvalidAccessTokenException;

--- a/src/main/java/org/runnect/server/course/controller/CourseController.java
+++ b/src/main/java/org/runnect/server/course/controller/CourseController.java
@@ -57,7 +57,7 @@ public class CourseController {
     @GetMapping("/user")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<CourseGetByUserResponseDto> getCourseByUser(@RequestHeader Long userId) {
-        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER,
+        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER_SUCCESS,
             courseService.getCourseByUser(userId));
     }
 
@@ -65,7 +65,7 @@ public class CourseController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<CourseGetByUserResponseDto> getPrivateCourseByUser(
         @RequestHeader Long userId) {
-        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER,
+        return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER_SUCCESS,
             courseService.getPrivateCourseByUser(userId));
     }
 

--- a/src/main/java/org/runnect/server/course/repository/CourseRepository.java
+++ b/src/main/java/org/runnect/server/course/repository/CourseRepository.java
@@ -17,13 +17,13 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     // READ
     @Query("select c from Course c join fetch c.runnectUser where c.runnectUser.id = :userId and c.deletedAt = null order by c.createdAt desc")
-    List<Course> findCourseByUserId(Long userId);
+    List<Course> findCourseByUserId(@Param("userId") Long userId);
 
     @Query("select c from Course c join fetch c.runnectUser where c.id = :courseId")
-    Optional<Course> findCourseByIdFetchUser(Long courseId);
+    Optional<Course> findCourseByIdFetchUser(@Param("courseId") Long courseId);
 
     @Query("select c from Course c join fetch c.runnectUser where c.runnectUser.id = :userId and c.isPrivate = true and c.deletedAt = null order by c.createdAt desc")
-    List<Course> findCourseByUserIdOnlyPrivate(Long userId);
+    List<Course> findCourseByUserIdOnlyPrivate(@Param("userId") Long userId);
 
     List<Course> findCoursesByRunnectUserAndIsPrivateIsFalse(RunnectUser runnectUser);
     long countByRunnectUser(RunnectUser runnectUser);

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -18,6 +18,8 @@ import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseD
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.recommendPublicCourse.RecommendPublicCourseResponseDto;
+import org.runnect.server.publicCourse.dto.response.searchPublicCourse.SearchPublicCourseResponseDto;
+
 import org.runnect.server.publicCourse.service.PublicCourseService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -10,6 +10,7 @@ import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto
 import org.runnect.server.publicCourse.dto.request.UpdatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.dto.response.GetPublicCourseDetailResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.service.PublicCourseService;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,17 @@ public class PublicCourseController {
     ){
 
         return ApiResponseDto.success(SuccessStatus.CREATE_PUBLIC_COURSE_SUCCESS, publicCourseService.createPublicCourse(userId, createPublicCourseRequestDto));
+
+    }
+
+    @GetMapping("/detail/{publicCourseId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetPublicCourseDetailResponseDto> getPublicCourseDetail(
+            @UserId final Long userId,
+            @PathVariable final Long publicCourseId
+    ){
+
+        return ApiResponseDto.success(SuccessStatus.GET_PUBLIC_COURSE_DETAIL_SUCCESS, publicCourseService.getPublicCourseDetail(userId, publicCourseId));
 
     }
 

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -1,6 +1,8 @@
 package org.runnect.server.publicCourse.controller;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.constant.SuccessStatus;
@@ -23,6 +25,21 @@ public class PublicCourseController {
 
     private final PublicCourseService publicCourseService;
 
+    @GetMapping("/search")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<SearchPublicCourseResponseDto> searchPublicCourse(
+            @UserId final Long userId,
+            @RequestParam @NotBlank String keyword
+    ){
+        return ApiResponseDto.success(SuccessStatus.SEARCH_PUBLIC_COURSE_SUCCESS,
+                publicCourseService.searchPublicCourse(userId, keyword));
+    }
+
+
+
+
+
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponseDto<CreatePublicCourseResponseDto> createPublicCourse(
@@ -31,9 +48,8 @@ public class PublicCourseController {
             //@RequestHeader final Long userId,
             @Valid @RequestBody final CreatePublicCourseRequestDto createPublicCourseRequestDto
     ){
-
-        return ApiResponseDto.success(SuccessStatus.CREATE_PUBLIC_COURSE_SUCCESS, publicCourseService.createPublicCourse(userId, createPublicCourseRequestDto));
-
+        return ApiResponseDto.success(SuccessStatus.CREATE_PUBLIC_COURSE_SUCCESS,
+                publicCourseService.createPublicCourse(userId, createPublicCourseRequestDto));
     }
 
     @GetMapping("/user")

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -1,9 +1,12 @@
 package org.runnect.server.publicCourse.controller;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.constant.SuccessStatus;
+import org.runnect.server.common.resolver.sort.SortStatusId;
 import org.runnect.server.common.resolver.userId.UserId;
 import org.runnect.server.publicCourse.dto.request.CreatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
@@ -12,6 +15,7 @@ import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDt
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
+import org.runnect.server.publicCourse.dto.response.recommendPublicCourse.RecommendPublicCourseResponseDto;
 import org.runnect.server.publicCourse.service.PublicCourseService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +26,21 @@ import org.springframework.web.bind.annotation.*;
 public class PublicCourseController {
 
     private final PublicCourseService publicCourseService;
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<RecommendPublicCourseResponseDto> recommendPublicCourse(
+            @UserId final Long userId,
+            @RequestParam(required = false) @Positive Integer pageNo,
+            @SortStatusId String sort
+    ){
+        if(pageNo == null){
+            pageNo = 1; //basic pageNo
+        }
+        return ApiResponseDto.success(SuccessStatus.GET_RECOMMENDED_PUBLIC_COURSE_SUCCESS, publicCourseService.recommendPublicCourse(userId, pageNo,sort));
+
+    }
+
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/GetPublicCourseDetailResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/GetPublicCourseDetailResponseDto.java
@@ -1,0 +1,94 @@
+package org.runnect.server.publicCourse.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPublicCourseDetailResponseDto {
+    private GetPublicCourseDetailUser user;
+    private GetPublicCourseDetailPublicCourse publicCourse;
+
+    public static GetPublicCourseDetailResponseDto of(String nickname, int level, String userImage, Boolean isNowUser,
+                                                      Long publicCourseId, Long courseId, Boolean isScrap, Long scrapCount,
+                                                      String courseImage, String title, String description, List<List<Double>> path,
+                                                      Float distance, String region, String city, String town, String name) {
+        return new GetPublicCourseDetailResponseDto(
+                GetPublicCourseDetailResponseDto.GetPublicCourseDetailUser.from(nickname, level, userImage, isNowUser),
+                GetPublicCourseDetailResponseDto.GetPublicCourseDetailPublicCourse.from(publicCourseId, courseId, isScrap, scrapCount, courseImage, title, description, path, distance, region, city, town, name));
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetPublicCourseDetailUser {
+        private String nickname;
+        private int level;
+        private String image;
+        private Boolean isNowUser;
+
+        public static GetPublicCourseDetailResponseDto.GetPublicCourseDetailUser from(String nickname, int level,
+                                                                                      String image, Boolean isNowUser) {
+            return new GetPublicCourseDetailResponseDto.GetPublicCourseDetailUser(nickname, level, image, isNowUser);
+        }
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetPublicCourseDetailPublicCourse {
+        private Long id;
+        private Long courseId;
+        private Boolean isScrap;
+        private Long scrapCount;
+        private String image;
+        private String title;
+        private String description;
+        private List<List<Double>> path;
+        private Float distance;
+        private GetPublicCourseDetailPublicCourseDeparture departure;
+
+        public static GetPublicCourseDetailResponseDto.GetPublicCourseDetailPublicCourse from(Long publicCourseId, Long courseId,
+                                                                                              Boolean isScrap, Long scrapCount,
+                                                                                              String courseImage, String title,
+                                                                                              String description, List<List<Double>> path,
+                                                                                              Float distance, String region,
+                                                                                              String city, String town, String name) {
+            return new GetPublicCourseDetailResponseDto
+                    .GetPublicCourseDetailPublicCourse(publicCourseId, courseId, isScrap, scrapCount,
+                    courseImage, title, description, path, distance,
+                    GetPublicCourseDetailResponseDto.GetPublicCourseDetailPublicCourse
+                    .GetPublicCourseDetailPublicCourseDeparture.from(region, city, town, name));
+        }
+
+
+        @Getter
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        @AllArgsConstructor(access = AccessLevel.PRIVATE)
+        public static class GetPublicCourseDetailPublicCourseDeparture {
+            private String region;
+            private String city;
+            private String town;
+            private String name;
+
+            public static GetPublicCourseDetailResponseDto
+                    .GetPublicCourseDetailPublicCourse
+                    .GetPublicCourseDetailPublicCourseDeparture from(String region, String city,
+                                                                     String town, String name) {
+                return new GetPublicCourseDetailResponseDto
+                        .GetPublicCourseDetailPublicCourse
+                        .GetPublicCourseDetailPublicCourseDeparture(region, city, town, name);
+            }
+        }
+    }
+}
+
+

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/recommendPublicCourse/RecommendPublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/recommendPublicCourse/RecommendPublicCourse.java
@@ -1,0 +1,36 @@
+package org.runnect.server.publicCourse.dto.response.recommendPublicCourse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecommendPublicCourse {
+    private Long id;
+    private Long courseId;
+    private String title;
+    private String image;
+    private Boolean scrap;
+    private RecommendPublicCourseDeparture departure;
+
+    public static RecommendPublicCourse of(Long id, Long courseId, String title, String image, Boolean scrap, String region, String city) {
+        return new RecommendPublicCourse(
+                id, courseId, title, image, scrap,
+                RecommendPublicCourse.RecommendPublicCourseDeparture.from(region, city));
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class RecommendPublicCourseDeparture {
+        private String region;
+        private String city;
+
+        public static RecommendPublicCourse.RecommendPublicCourseDeparture from(String region, String city) {
+            return new RecommendPublicCourse.RecommendPublicCourseDeparture(region, city);
+        }
+    }
+}

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/recommendPublicCourse/RecommendPublicCourseResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/recommendPublicCourse/RecommendPublicCourseResponseDto.java
@@ -1,0 +1,20 @@
+package org.runnect.server.publicCourse.dto.response.recommendPublicCourse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecommendPublicCourseResponseDto {
+    private String ordering;
+    private List<RecommendPublicCourse> publicCourses;
+
+    public static RecommendPublicCourseResponseDto of(String ordering, List<RecommendPublicCourse> publicCourses) {
+        return new RecommendPublicCourseResponseDto(ordering, publicCourses);
+    }
+}

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/searchPublicCourse/SearchPublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/searchPublicCourse/SearchPublicCourse.java
@@ -1,0 +1,39 @@
+package org.runnect.server.publicCourse.dto.response.searchPublicCourse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchPublicCourse {
+    private Long id;
+    private Long courseId;
+    private String title;
+    private String image;
+    private Boolean scrap;
+    private SearchPublicCourseDeparture departure;
+
+    public static SearchPublicCourse of(Long id, Long courseId, String title, String image, Boolean scrap, String region, String city) {
+        return new SearchPublicCourse(
+                id, courseId, title, image, scrap,
+                SearchPublicCourse.SearchPublicCourseDeparture.from(region, city));
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class SearchPublicCourseDeparture {
+        private String region;
+        private String city;
+
+        public static SearchPublicCourse.SearchPublicCourseDeparture from(String region, String city) {
+            return new SearchPublicCourse.SearchPublicCourseDeparture(region, city);
+        }
+    }
+
+
+}
+

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/searchPublicCourse/SearchPublicCourseResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/searchPublicCourse/SearchPublicCourseResponseDto.java
@@ -1,0 +1,20 @@
+package org.runnect.server.publicCourse.dto.response.searchPublicCourse;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchPublicCourseResponseDto {
+    private List<SearchPublicCourse> publicCourses;
+
+    public static SearchPublicCourseResponseDto of(List<SearchPublicCourse> publicCourses) {
+        return new SearchPublicCourseResponseDto(publicCourses);
+    }
+}

--- a/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Formula;
 import org.runnect.server.common.entity.AuditingTimeEntity;
 import org.runnect.server.course.entity.Course;
 import org.runnect.server.record.entity.Record;
@@ -38,12 +39,12 @@ public class PublicCourse extends AuditingTimeEntity {
     @Column(nullable = false)
     private String description;
 
-    // 아래 코드 주석이유 -> 유저가 현재 스크랩한 코스는 scraptf가 treu인 경우만임
-//    @OneToMany(mappedBy = "publicCourse")
-//    private List<Scrap> scraps = new ArrayList<>();
 
     @OneToMany(mappedBy = "publicCourse")
     private List<Record> records = new ArrayList<>();
+
+    @Formula("(select count(*) from Scrap where Scrap.public_course_id=id and Scrap.scraptf=true)")
+    private Integer scrapCount;
 
     @Transient
     private Boolean isScrap=false; //현재 사용자가 스크랩한지 아닌지 여부

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -3,12 +3,14 @@ package org.runnect.server.publicCourse.repository;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.user.entity.RunnectUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Long> {
     // CREATE
@@ -25,8 +27,16 @@ public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Lon
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
 
-    //Page<PublicCourse> findPageOrderByCreatedAt(Pageable pageable);
-    //Page<PublicCourse> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("SELECT pc " +
+            "FROM PublicCourse pc JOIN FETCH pc.course c " +
+            "WHERE pc.title LIKE CONCAT('%',LOWER(:keyword),'%') " +
+            "OR c.departureRegion LIKE CONCAT('%',LOWER(:keyword),'%') " +
+            "OR c.departureCity LIKE CONCAT('%',LOWER(:keyword),'%') " +
+            "OR c.departureTown LIKE CONCAT('%',LOWER(:keyword),'%') " +
+            "OR c.departureDetail LIKE CONCAT('%',LOWER(:keyword),'%') " +
+            "OR c.departureName LIKE CONCAT('%',LOWER(:keyword),'%') ")
+    List<PublicCourse> searchPublicCourseByKeyword(@Param("keyword") String keyword);
+
     Page<PublicCourse> findAll(Pageable pageable);
 
     // DELETE

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.user.entity.RunnectUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -22,6 +24,10 @@ public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Lon
     List<PublicCourse> findPublicCoursesByRunnectUser(RunnectUser user);
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
+
+    //Page<PublicCourse> findPageOrderByCreatedAt(Pageable pageable);
+    //Page<PublicCourse> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<PublicCourse> findAll(Pageable pageable);
 
     // DELETE
 }

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -7,19 +7,20 @@ import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.user.entity.RunnectUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Long> {
     // CREATE
 
     // READ
     @Query("SELECT pc FROM PublicCourse pc JOIN FETCH pc.course WHERE pc.id = :publicCourseId")
-    Optional<PublicCourse> findById(Long publicCourseId);
+    Optional<PublicCourse> findById(@Param("publicCourseId") Long publicCourseId);
 
     @Query("select count(pc.id) from PublicCourse pc where pc.runnectUser = :user")
-    Long countPublicCourseByUser(RunnectUser user);
+    Long countPublicCourseByUser(@Param("user") RunnectUser user);
 
     @Query("select pc from PublicCourse pc join fetch pc.course where pc.runnectUser = :user")
-    List<PublicCourse> findPublicCoursesByRunnectUser(RunnectUser user);
+    List<PublicCourse> findPublicCoursesByRunnectUser(@Param("user") RunnectUser user);
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
 

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -37,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PublicCourseService {
+    private static final Integer PAGE_SIZE = 10;
 
     private final PublicCourseRepository publicCourseRepository;
     private final UserRepository userRepository;
@@ -59,12 +60,12 @@ public class PublicCourseService {
         Page<PublicCourse> publicCourses = null;
         if(SortStatus.SCRAP_DESC.getVlaue().equals(sort)){
             publicCourses = publicCourseRepository.findAll(
-                    PageRequest.of(pageNo-1, 10,
+                    PageRequest.of(pageNo-1, PAGE_SIZE,
                             Sort.by(Sort.Direction.DESC,SortStatus.SCRAP_DESC.getProperty())));
 
         } else if (SortStatus.DATE_DESC.getVlaue().equals(sort)) {
             publicCourses = publicCourseRepository.findAll(
-                    PageRequest.of(pageNo-1, 10,
+                    PageRequest.of(pageNo-1, PAGE_SIZE,
                             Sort.by(Sort.Direction.DESC,SortStatus.DATE_DESC.getProperty())));
         }
 

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -7,12 +7,14 @@ import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.exception.ConflictException;
 import org.runnect.server.common.exception.NotFoundException;
 import org.runnect.server.common.exception.PermissionDeniedException;
+import org.runnect.server.course.dto.response.GetCourseDetailResponseDto;
 import org.runnect.server.course.entity.Course;
 import org.runnect.server.course.repository.CourseRepository;
 import org.runnect.server.publicCourse.dto.request.CreatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.dto.response.GetPublicCourseDetailResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.publicCourse.repository.PublicCourseRepository;
@@ -32,6 +34,29 @@ public class PublicCourseService {
     private final UserRepository userRepository;
     private final ScrapRepository scrapRepository;
     private final CourseRepository courseRepository;
+
+    public GetPublicCourseDetailResponseDto getPublicCourseDetail(final Long userId, final Long publicCourseId){
+        //0. 유저가 존재하는지
+        RunnectUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
+                        ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        //1. publicCourse가 존재하는지
+        PublicCourse publicCourse = publicCourseRepository.findById(publicCourseId).orElseThrow(()->new NotFoundException(ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION,
+                ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION.getMessage()));
+
+        //2. 이미 삭제된 코스인지
+        if(publicCourse.getCourse().getDeletedAt()==null){
+            new NotFoundException(ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION,
+                    ErrorStatus.NOT_FOUND_PUBLIC_COURSE_EXCEPTION.getMessage());
+        }
+
+        return GetPublicCourseDetailResponseDto.of(user.getNickname(),user.getLevel(),user.getLatestStamp().name(),publicCourse.getCourse().getRunnectUser().equals(user),
+                publicCourse.getId(), publicCourse.getCourse().getId(),)
+
+
+
+    }
 
     @Transactional
     public CreatePublicCourseResponseDto createPublicCourse(

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.constant.ErrorStatus;
+import org.runnect.server.common.constant.SortStatus;
 import org.runnect.server.common.exception.ConflictException;
 import org.runnect.server.common.exception.NotFoundException;
 import org.runnect.server.common.exception.PermissionDeniedException;
@@ -17,6 +18,8 @@ import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseD
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserPublicCourse;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
+import org.runnect.server.publicCourse.dto.response.recommendPublicCourse.RecommendPublicCourse;
+import org.runnect.server.publicCourse.dto.response.recommendPublicCourse.RecommendPublicCourseResponseDto;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.publicCourse.repository.PublicCourseRepository;
 import org.runnect.server.record.entity.Record;
@@ -25,6 +28,9 @@ import org.runnect.server.scrap.repository.ScrapRepository;
 import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
 import org.runnect.server.user.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +43,51 @@ public class PublicCourseService {
     private final ScrapRepository scrapRepository;
     private final CourseRepository courseRepository;
 
+
+    public RecommendPublicCourseResponseDto recommendPublicCourse(Long userId, Integer pageNo, String sort){
+        //1. 받은 userId가 유저가 존재하는지 확인
+        RunnectUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
+                        ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        //2. 유저가 스크랩한 코스들 가져오기
+        List<Scrap> scraps = scrapRepository.findAllByUserIdAndScrapTF(userId).get();
+
+
+        //3. page, sort 에 따라 데이터 가져오기
+        List<RecommendPublicCourse> recommendPublicCourses = new ArrayList<>();
+        Page<PublicCourse> publicCourses = null;
+        if(SortStatus.SCRAP_DESC.getVlaue().equals(sort)){
+            publicCourses = publicCourseRepository.findAll(
+                    PageRequest.of(pageNo-1, 10,
+                            Sort.by(Sort.Direction.DESC,SortStatus.SCRAP_DESC.getProperty())));
+
+        } else if (SortStatus.DATE_DESC.getVlaue().equals(sort)) {
+            publicCourses = publicCourseRepository.findAll(
+                    PageRequest.of(pageNo-1, 10,
+                            Sort.by(Sort.Direction.DESC,SortStatus.DATE_DESC.getProperty())));
+        }
+
+        publicCourses.forEach(publicCourse->{
+            //4. 각 코스들의 publicCourse와 scrap 여부 파악
+            scraps.forEach(scrap->
+                    publicCourse.setIsScrap(scrap.getPublicCourse().equals(publicCourse)));
+
+            recommendPublicCourses.add(
+                    RecommendPublicCourse.of(
+                            publicCourse.getId(),
+                            publicCourse.getCourse().getId(),
+                            publicCourse.getTitle(),
+                            publicCourse.getCourse().getImage(),
+                            publicCourse.getIsScrap(),
+                            publicCourse.getCourse().getDepartureRegion(),
+                            publicCourse.getCourse().getDepartureCity()));
+        });
+
+
+        return RecommendPublicCourseResponseDto.of(sort,recommendPublicCourses);
+
+    }
 
     public GetPublicCourseByUserResponseDto getPublicCourseByUser(Long userId){
         List<GetPublicCourseByUserPublicCourse> getPublicCourseByUserPublicCourses = new ArrayList<>();

--- a/src/main/java/org/runnect/server/record/controller/RecordController.java
+++ b/src/main/java/org/runnect/server/record/controller/RecordController.java
@@ -40,7 +40,7 @@ public class RecordController {
     @GetMapping("record/user")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<GetRecordResponseDto> getRecordByUser(@RequestHeader Long userId) {
-        return ApiResponseDto.success(SuccessStatus.READ_RECORD_SUCCESS, recordService.getRecordByUser(userId));
+        return ApiResponseDto.success(SuccessStatus.GET_RECORD_SUCCESS, recordService.getRecordByUser(userId));
     }
 
     @PatchMapping("record/{recordId}")

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -28,4 +28,5 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
     // DELETE
     Long deleteByPublicCourseIn(Collection<PublicCourse> publicCourses);
 
+    Long countByPublicCourseAndScrapTFIsTrue(PublicCourse publicCourse);
 }

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -16,7 +16,7 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
 
     // READ
     @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse WHERE s.runnectUser.id = :userId AND s.publicCourse.id = :publicCourseId")
-    Optional<Scrap> findByUserIdAndPublicCourseId(Long userId, Long publicCourseId);
+    Optional<Scrap> findByUserIdAndPublicCourseId(@Param("userId") Long userId, @Param("publicCourseId") Long publicCourseId);
 
     @Query("SELECT s FROM Scrap s JOIN FETCH s.publicCourse pc JOIN FETCH pc.course c WHERE s.runnectUser.id = :userId AND s.scrapTF = true")
     Optional<List<Scrap>> findAllByUserIdAndScrapTF(@Param("userId") Long userId);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #78 

### 🤔 어떻게 이슈를 해결했나요?

---
`BASE URL/api/public-course?pageNo={페이지번호}&sort={정렬방법}`

- 위의 url중 각 파라미터가 없거나 null 일때는 default 값(pageNo ->1, sort -> 최신순(date))으로 변환하도록 커스텀 어노테이션과 spring validator 사용 
- 스크랩 많은 순을 구현하기위해 PublicCourse entity에 서브쿼리 칼럼 scrapCount 작성
- entity에 명시적으로 칼럼 scapCount가 작성되어 Sort 클래스의 sorting property로 동작가능
- 추가적인 정렬 가능성을 생각해 SortStatus Enum 객체 작성

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
<img width="1440" alt="스크린샷 2023-11-09 오후 9 40 09" src="https://github.com/Runnect/Runnect-Spring-Boot-Server/assets/65851554/cfd0ee04-e2eb-461f-9cd1-6b40a2209469">


<img width="1440" alt="스크린샷 2023-11-09 오후 9 40 31" src="https://github.com/Runnect/Runnect-Spring-Boot-Server/assets/65851554/c2cb7361-145e-430c-9abf-c0c70829f7fe">

<img width="1440" alt="스크린샷 2023-11-09 오후 9 41 06" src="https://github.com/Runnect/Runnect-Spring-Boot-Server/assets/65851554/ebfde6cb-93b8-4c50-a611-4bf58aada21a">
