### PR TITLE
[Feat] getPublicCourseTotalPageCount 

### DIFF
--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -30,6 +30,7 @@ public enum SuccessStatus {
     GET_PUBLIC_COURSE_BY_USER_SUCCESS(HttpStatus.OK,"유저가 업로드한 코스 조회 성공"),
     DELETE_COURSES_SUCCESS(HttpStatus.OK, "코스 삭제 성공"),
     GET_USER_STAMPS_SUCCESS(HttpStatus.OK, "유저 스탬프 조회 성공"),
+    GET_PUBLIC_COURSE_TOTAL_PAGE_COUNT_SUCCESS(HttpStatus.OK,"추천 코스 전체 페이지 개수 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -10,6 +10,7 @@ import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto
 import org.runnect.server.publicCourse.dto.request.UpdatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.dto.response.GetPublicCourseTotalPageCountResponseDto;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.service.PublicCourseService;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class PublicCourseController {
 
     private final PublicCourseService publicCourseService;
+
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -47,6 +49,13 @@ public class PublicCourseController {
         return ApiResponseDto.success(SuccessStatus.GET_PUBLIC_COURSE_BY_USER_SUCCESS,
                 publicCourseService.getPublicCourseByUser(userId));
 
+    }
+
+    @GetMapping("/total-page-count")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetPublicCourseTotalPageCountResponseDto> getPublicCourseTotalPageCount(){
+        return ApiResponseDto.success(SuccessStatus.GET_PUBLIC_COURSE_TOTAL_PAGE_COUNT_SUCCESS,
+                publicCourseService.getPublicCourseTotalPageCount());
     }
 
 

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/GetPublicCourseTotalPageCountResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/GetPublicCourseTotalPageCountResponseDto.java
@@ -1,0 +1,17 @@
+package org.runnect.server.publicCourse.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetPublicCourseTotalPageCountResponseDto {
+    private Long totalPageCount;
+
+    public static GetPublicCourseTotalPageCountResponseDto of(Long totalPageCount){
+        return new GetPublicCourseTotalPageCountResponseDto(totalPageCount);
+    }
+}

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -23,5 +23,7 @@ public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Lon
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
 
+    Long countBy();
+
     // DELETE
 }

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -14,6 +14,7 @@ import org.runnect.server.publicCourse.dto.request.CreatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
+import org.runnect.server.publicCourse.dto.response.GetPublicCourseTotalPageCountResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserPublicCourse;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
@@ -31,12 +32,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PublicCourseService {
+    private static final Integer PAGE_SIZE = 10;
+
 
     private final PublicCourseRepository publicCourseRepository;
     private final UserRepository userRepository;
     private final ScrapRepository scrapRepository;
     private final CourseRepository courseRepository;
 
+    public GetPublicCourseTotalPageCountResponseDto getPublicCourseTotalPageCount(){
+        Long totalPublicCourseCount = publicCourseRepository.countBy();
+        if(totalPublicCourseCount%PAGE_SIZE!=0){
+            return GetPublicCourseTotalPageCountResponseDto.of(totalPublicCourseCount/PAGE_SIZE+1);
+        }
+        return GetPublicCourseTotalPageCountResponseDto.of(totalPublicCourseCount/PAGE_SIZE);
+    }
 
     public GetPublicCourseByUserResponseDto getPublicCourseByUser(Long userId){
         List<GetPublicCourseByUserPublicCourse> getPublicCourseByUserPublicCourses = new ArrayList<>();


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #80 

### 🤔 어떻게 이슈를 해결했나요?

---

- publicCourse는 그 삭제 플로우 특성상 db에 있는 publicCourse 테이블 data count = 유효한 publicCoures data Count임
- 그러기에 pageSize 유닛으로 나눠 반환
- 이때 나누어떨어지지 않은 경우는 pageSize보다 적은 수를 반환하는 마지막 페이지로 간주해 +1


### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
