### PR TITLE
[Fix] deletePublicCourse,deleteCourse

### DIFF
--- a/src/main/java/org/runnect/server/course/entity/Course.java
+++ b/src/main/java/org/runnect/server/course/entity/Course.java
@@ -90,4 +90,8 @@ public class Course extends AuditingTimeEntity {
         this.isPrivate = false;
     }
 
+    public void retrieveCourse() {
+        isPrivate = true;
+    }
+
 }

--- a/src/main/java/org/runnect/server/course/repository/CourseRepository.java
+++ b/src/main/java/org/runnect/server/course/repository/CourseRepository.java
@@ -26,6 +26,8 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     List<Course> findCourseByUserIdOnlyPrivate(Long userId);
 
     List<Course> findCoursesByRunnectUserAndIsPrivateIsFalse(RunnectUser runnectUser);
+    List<Course> findCoursesByRunnectUserAndIsPrivateIsTrue(RunnectUser runnectUser);
+
     long countByRunnectUser(RunnectUser runnectUser);
 
     Optional<Course> findById(Long courseId);

--- a/src/main/java/org/runnect/server/course/service/CourseService.java
+++ b/src/main/java/org/runnect/server/course/service/CourseService.java
@@ -21,6 +21,7 @@ import org.runnect.server.course.dto.response.UpdateCourseResponseDto;
 import org.runnect.server.course.dto.response.UserResponse;
 import org.runnect.server.course.entity.Course;
 import org.runnect.server.course.repository.CourseRepository;
+import org.runnect.server.publicCourse.repository.PublicCourseRepository;
 import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.entity.StampType;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
@@ -34,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CourseService {
 
     private final CourseRepository courseRepository;
+    private final PublicCourseRepository publicCourseRepository;
     private final UserRepository userRepository;
     private final UserStampService userStampService;
 
@@ -135,6 +137,10 @@ public class CourseService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_COURSE_EXCEPTION,
                     NOT_FOUND_COURSE_EXCEPTION.getMessage()));
 
+            if(!course.getIsPrivate()){
+                publicCourseRepository.delete(course.getPublicCourse());
+                course.retrieveCourse();
+            }
             course.updateDeletedAt();
         });
         return DeleteCoursesResponseDto.from(courseIdList.size());

--- a/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
@@ -10,6 +10,7 @@ import org.runnect.server.record.entity.Record;
 import org.runnect.server.scrap.entity.Scrap;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.runnect.server.user.entity.RunnectUser;
@@ -57,5 +58,10 @@ public class PublicCourse extends AuditingTimeEntity {
     public void updatePublicCourse(String title, String description) {
         this.title = title;
         this.description = description;
+    }
+
+    @Override
+    public void updateDeletedAt() {
+        throw new RuntimeException("Course를 제외한 테이블은 정상적으로 삭제됩니다.");
     }
 }

--- a/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/entity/PublicCourse.java
@@ -24,9 +24,6 @@ public class PublicCourse extends AuditingTimeEntity {
     private Long id;
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private RunnectUser runnectUser;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)
@@ -51,9 +48,8 @@ public class PublicCourse extends AuditingTimeEntity {
     public void setIsScrap(Boolean flag){ isScrap=flag;}
 
     @Builder
-    public PublicCourse(Course course, RunnectUser user, String title, String description) {
+    public PublicCourse(Course course, String title, String description) {
         this.course = course;
-        this.runnectUser = user;
         this.title = title;
         this.description = description;
     }

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -15,11 +15,9 @@ public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Lon
     @Query("SELECT pc FROM PublicCourse pc JOIN FETCH pc.course WHERE pc.id = :publicCourseId")
     Optional<PublicCourse> findById(Long publicCourseId);
 
-    @Query("select count(pc.id) from PublicCourse pc where pc.runnectUser = :user")
-    Long countPublicCourseByUser(RunnectUser user);
-
-    @Query("select pc from PublicCourse pc join fetch pc.course where pc.runnectUser = :user")
-    List<PublicCourse> findPublicCoursesByRunnectUser(RunnectUser user);
+//    @Query("select count(pc.id) from PublicCourse pc where pc.runnectUser = :user")
+//    Long countPublicCourseByUser(RunnectUser user);
+// 어디서쓰이지? 안쓰는 거면 삭제할예정
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
 

--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -19,11 +19,6 @@ public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Lon
     @Query("SELECT pc FROM PublicCourse pc JOIN FETCH pc.course WHERE pc.id = :publicCourseId")
     Optional<PublicCourse> findById(@Param("publicCourseId") Long publicCourseId);
 
-    @Query("select count(pc.id) from PublicCourse pc where pc.runnectUser = :user")
-    Long countPublicCourseByUser(@Param("user") RunnectUser user);
-
-    @Query("select pc from PublicCourse pc join fetch pc.course where pc.runnectUser = :user")
-    List<PublicCourse> findPublicCoursesByRunnectUser(@Param("user") RunnectUser user);
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
 

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -147,10 +147,7 @@ public class PublicCourseService {
                             ErrorStatus.PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION.getMessage());
                 });
 
-
-        scrapRepository.deleteByPublicCourseIn(publicCourses);
-        publicCourses.forEach(publicCourse -> publicCourse.getRecords().forEach(Record::setPublicCourseNull));
-        publicCourses.forEach(PublicCourse::updateDeletedAt);
+        publicCourseRepository.deleteAllInBatch(publicCourses);
 
         return DeletePublicCoursesResponseDto.from(publicCourses.size());
     }

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -107,7 +107,6 @@ public class PublicCourseService {
         //5. pulblicCourse를 생성후 저장
         PublicCourse publicCourse = PublicCourse.builder()
                 .course(course)
-                .user(user)
                 .title(createPublicCourseRequestDto.getTitle())
                 .description(createPublicCourseRequestDto.getDescription())
                 .build();
@@ -140,7 +139,7 @@ public class PublicCourseService {
         }
 
         publicCourses.stream()
-                .filter(pc -> !pc.getRunnectUser().equals(user))
+                .filter(pc -> !pc.getCourse().getRunnectUser().equals(user))
                 .findAny()
                 .ifPresent(pc -> {
                     throw new PermissionDeniedException(

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -147,6 +147,9 @@ public class PublicCourseService {
                             ErrorStatus.PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION.getMessage());
                 });
 
+        //삭제전 course의 isPrivate update
+        publicCourses.forEach(publicCourse -> publicCourse.getCourse().retrieveCourse());
+
         publicCourseRepository.deleteAllInBatch(publicCourses);
 
         return DeletePublicCoursesResponseDto.from(publicCourses.size());

--- a/src/main/java/org/runnect/server/record/entity/Record.java
+++ b/src/main/java/org/runnect/server/record/entity/Record.java
@@ -32,7 +32,7 @@ public class Record extends AuditingTimeEntity {
     private RunnectUser runnectUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id")
+    @JoinColumn(name = "course_id", nullable = false)
     private Course course;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/runnect/server/record/entity/Record.java
+++ b/src/main/java/org/runnect/server/record/entity/Record.java
@@ -65,4 +65,9 @@ public class Record extends AuditingTimeEntity {
     public void setPublicCourseNull() {
         this.publicCourse = null;
     }
+
+    @Override
+    public void updateDeletedAt() {
+        throw new RuntimeException("Course를 제외한 테이블은 정상적으로 삭제됩니다.");
+    }
 }

--- a/src/main/java/org/runnect/server/scrap/entity/Scrap.java
+++ b/src/main/java/org/runnect/server/scrap/entity/Scrap.java
@@ -48,4 +48,9 @@ public class Scrap extends AuditingTimeEntity {
         this.scrapTF = scrapTF;
     }
 
+    @Override
+    public void updateDeletedAt() {
+        throw new RuntimeException("Course를 제외한 테이블은 정상적으로 삭제됩니다.");
+    }
+
 }

--- a/src/main/java/org/runnect/server/user/entity/RunnectUser.java
+++ b/src/main/java/org/runnect/server/user/entity/RunnectUser.java
@@ -116,4 +116,9 @@ public class RunnectUser extends AuditingTimeEntity {
     public void updateCreatedPublicCourse() {
         this.createdPublicCourse++;
     }
+
+    @Override
+    public void updateDeletedAt() {
+        throw new RuntimeException("Course를 제외한 테이블은 정상적으로 삭제됩니다.");
+    }
 }

--- a/src/main/java/org/runnect/server/user/entity/UserStamp.java
+++ b/src/main/java/org/runnect/server/user/entity/UserStamp.java
@@ -31,4 +31,9 @@ public class UserStamp extends AuditingTimeEntity {
         this.runnectUser = runnectUser;
     }
 
+    @Override
+    public void updateDeletedAt() {
+        throw new RuntimeException("Course를 제외한 테이블은 정상적으로 삭제됩니다.");
+    }
+
 }

--- a/src/main/java/org/runnect/server/user/service/UserService.java
+++ b/src/main/java/org/runnect/server/user/service/UserService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.constant.ErrorStatus;
+import org.runnect.server.course.entity.Course;
+import org.runnect.server.course.repository.CourseRepository;
 import org.runnect.server.user.dto.request.UpdateUserNicknameRequestDto;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.publicCourse.repository.PublicCourseRepository;
@@ -25,8 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final PublicCourseRepository publicCourseRepository;
     private final ScrapRepository scrapRepository;
+    private final CourseRepository courseRepository;
 
     @Transactional(readOnly = true)
     public MyPageResponseDto getMyPage(Long userId) {
@@ -66,8 +68,8 @@ public class UserService {
             .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
                 ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
-        List<PublicCourse> publicCourses = publicCourseRepository.findPublicCoursesByRunnectUser(
-            profileUser);
+        List<PublicCourse> publicCourses = courseRepository.findCoursesByRunnectUserAndIsPrivateIsTrue(profileUser)
+                .stream().map(course -> course.getPublicCourse()).collect(Collectors.toList());
 
         List<PublicCourseResponse> publicCourseResponses = publicCourses.stream()
             .map(publicCourse ->


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #81 


### 🤔 어떻게 이슈를 해결했나요?

---

- 운영 db와 개발 db 제약조건동일화
- 운영 db와 개발 db의 코드상 다른 제약조건(publicCourse에 userfk, record couse nullable) 수정
- course를 제외한 다른 entity는 updateDeletedAt() 메소드 사용막음
- deletePublicCourse 완전삭제 후 course isPrivate true로 변경
- deleteCourse는 updateDetetdAt()이후 연관된 PublicCourse 삭제, isPrivate treu update

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->

고민인점....
fk 양방향 전환이 가능해지면서....
course.isPrivate, record.PublicCourse의 이 두개의 칼럼의 존재의미가 애매해짐.

1. 칼럼을 db에서도 삭제하거나
2. 운영 db와의 문제도 있을수있으니, get해당칼럼을 private로 변경하거나 하는게 어떤지
