### PR TITLE
[Feat] getMarathonPublicCourse

### DIFF
--- a/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/ErrorStatus.java
@@ -27,6 +27,9 @@ public enum ErrorStatus {
     UNMATCHED_COURSE_EXCEPTION(HttpStatus.BAD_REQUEST, "로그인된 유저가 그린 코스가 아닙니다."),
     INVALID_SORT_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "sort 파라미터에 올바른 값이 입력되지 않았습니다."),
     INVALID_PARAMETER_EXCEPTION(HttpStatus.BAD_REQUEST, "파라미터에 올바른 값이 입력되지 않았습니다."),
+    NOT_FOUND_SCRAP_EXCEPTION(HttpStatus.BAD_REQUEST, "스크랩한 코스가 없습니다."),
+    NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 이미지 파일입니다"),
+    NOT_FOUND_PUBLICCOURSE_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 public course id입니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -49,10 +52,7 @@ public enum ErrorStatus {
      * 404 NOT FOUND
      */
     NOT_FOUND_USER_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다"),
-    NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 이미지 파일입니다"),
-    NOT_FOUND_PUBLICCOURSE_EXCEPTION(HttpStatus.BAD_REQUEST, "존재하지 않는 public course id입니다."),
-    NOT_FOUND_SCRAP_EXCEPTION(HttpStatus.BAD_REQUEST, "스크랩한 코스가 없습니다."),
-
+    NOT_FOUND_MARATHON_PUBLIC_COURSE_EXCEPTION(HttpStatus.NOT_FOUND, "마라톤 코스가 존재하지 않습니다."),
     /**
      * 409 CONFLICT
      */

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -33,6 +33,7 @@ public enum SuccessStatus {
     GET_RECOMMENDED_PUBLIC_COURSE_SUCCESS(HttpStatus.OK, "추천 코스 조회 성공"),
     SEARCH_PUBLIC_COURSE_SUCCESS(HttpStatus.OK,"업로드된 코스 검색 성공"),
     GET_PUBLIC_COURSE_DETAIL_SUCCESS(HttpStatus.OK,"업로드 코스 상세 조회 성공"),
+    GET_MARATHON_PUBLIC_COURSE_SUCCESS(HttpStatus.OK,"마라톤 코스 조회 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -16,6 +16,7 @@ import org.runnect.server.publicCourse.dto.request.UpdatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
 import org.runnect.server.publicCourse.dto.response.GetPublicCourseDetailResponseDto;
+import org.runnect.server.publicCourse.dto.response.getMarathonPublicCourse.GetMarathonPublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.recommendPublicCourse.RecommendPublicCourseResponseDto;
@@ -58,7 +59,14 @@ public class PublicCourseController {
     }
 
 
-
+    @GetMapping("/marathon")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetMarathonPublicCourseResponseDto> getMarathonPublicCourse(
+            @UserId final Long userId
+    ){
+        return ApiResponseDto.success(SuccessStatus.GET_MARATHON_PUBLIC_COURSE_SUCCESS,
+                publicCourseService.getMarathonPublicCourse(userId));
+    }
 
 
 

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/getMarathonPublicCourse/GetMarathonPublicCourse.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/getMarathonPublicCourse/GetMarathonPublicCourse.java
@@ -1,0 +1,39 @@
+package org.runnect.server.publicCourse.dto.response.getMarathonPublicCourse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMarathonPublicCourse {
+    private Long id;
+    private Long courseId;
+    private String title;
+    private String image;
+    private Boolean scrap;
+    private GetMarathonPublicCourseDeparture departure;
+
+    public static GetMarathonPublicCourse of(Long id, Long courseId, String title, String image, Boolean scrap, String region, String city) {
+        return new GetMarathonPublicCourse(
+                id, courseId, title, image, scrap,
+                GetMarathonPublicCourse.GetMarathonPublicCourseDeparture.from(region, city));
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class GetMarathonPublicCourseDeparture {
+        private String region;
+        private String city;
+
+        public static GetMarathonPublicCourse.GetMarathonPublicCourseDeparture from(String region, String city) {
+            return new GetMarathonPublicCourse.GetMarathonPublicCourseDeparture(region, city);
+        }
+    }
+
+
+}
+

--- a/src/main/java/org/runnect/server/publicCourse/dto/response/getMarathonPublicCourse/GetMarathonPublicCourseResponseDto.java
+++ b/src/main/java/org/runnect/server/publicCourse/dto/response/getMarathonPublicCourse/GetMarathonPublicCourseResponseDto.java
@@ -1,0 +1,20 @@
+package org.runnect.server.publicCourse.dto.response.getMarathonPublicCourse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMarathonPublicCourseResponseDto {
+    private List<GetMarathonPublicCourse> marathonPublicCourses;
+
+    public static GetMarathonPublicCourseResponseDto of(List<GetMarathonPublicCourse> marathonPublicCourses) {
+        return new GetMarathonPublicCourseResponseDto(marathonPublicCourses);
+    }
+
+}

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -1,9 +1,13 @@
 package org.runnect.server.publicCourse.service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Before;
 import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.constant.SortStatus;
 import org.runnect.server.common.exception.ConflictException;
@@ -19,6 +23,8 @@ import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDt
 import org.runnect.server.publicCourse.dto.response.DeletePublicCoursesResponseDto;
 import org.runnect.server.publicCourse.dto.response.GetPublicCourseDetailResponseDto;
 import org.runnect.server.publicCourse.dto.response.UpdatePublicCourseResponseDto;
+import org.runnect.server.publicCourse.dto.response.getMarathonPublicCourse.GetMarathonPublicCourse;
+import org.runnect.server.publicCourse.dto.response.getMarathonPublicCourse.GetMarathonPublicCourseResponseDto;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserPublicCourse;
 import org.runnect.server.publicCourse.dto.response.getPublicCourseByUser.GetPublicCourseByUserResponseDto;
 import org.runnect.server.publicCourse.dto.response.recommendPublicCourse.RecommendPublicCourse;
@@ -33,6 +39,7 @@ import org.runnect.server.scrap.repository.ScrapRepository;
 import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
 import org.runnect.server.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -43,12 +50,53 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PublicCourseService {
     private static final Integer PAGE_SIZE = 10;
+    private static List<Long> MARATHON_PUBLIC_COURSE_IDS;
 
     private final PublicCourseRepository publicCourseRepository;
     private final UserRepository userRepository;
     private final ScrapRepository scrapRepository;
     private final CourseRepository courseRepository;
 
+    @Value("${runnect.marathon-public-course-id}")
+    public void setMARATHON_PUBLIC_COURSE_IDS(String MARATHON_PUBLIC_COURSE_ID) {
+        this.MARATHON_PUBLIC_COURSE_IDS = Stream.of(MARATHON_PUBLIC_COURSE_ID.split(","))
+                .map(Long::parseLong).collect(Collectors.toList());
+    }
+
+    public GetMarathonPublicCourseResponseDto getMarathonPublicCourse(Long userId){
+        //1. 받은 userId가 유저가 존재하는지 확인
+        RunnectUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
+                        ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        //2. 유저가 스크랩한 코스들 가져오기
+        List<Scrap> scraps = scrapRepository.findAllByUserIdAndScrapTF(userId).get();
+
+        //3. 마라톤 코스들 가져오기
+        List<PublicCourse> marathonPublicCourses = publicCourseRepository.findByIdIn(MARATHON_PUBLIC_COURSE_IDS);
+        if(marathonPublicCourses.size() != MARATHON_PUBLIC_COURSE_IDS.size()){
+            throw new NotFoundException(ErrorStatus.NOT_FOUND_MARATHON_PUBLIC_COURSE_EXCEPTION,
+                    ErrorStatus.NOT_FOUND_MARATHON_PUBLIC_COURSE_EXCEPTION.getMessage());
+        }
+
+        List<GetMarathonPublicCourse> getMarathonPublicCourses = new ArrayList<>();
+        marathonPublicCourses.forEach(marathonPublicCourse->{
+            //4. 각 코스들의 publicCourse와 scrap 여부 파악
+            scraps.forEach(scrap-> marathonPublicCourse.setIsScrap(scrap.getPublicCourse().equals(marathonPublicCourse)));
+
+            getMarathonPublicCourses.add(GetMarathonPublicCourse.of(
+                    marathonPublicCourse.getId(),
+                    marathonPublicCourse.getCourse().getId(),
+                    marathonPublicCourse.getTitle(),
+                    marathonPublicCourse.getCourse().getImage(),
+                    marathonPublicCourse.getIsScrap(),
+                    marathonPublicCourse.getCourse().getDepartureRegion(),
+                    marathonPublicCourse.getCourse().getDepartureCity()));
+        });
+
+        return GetMarathonPublicCourseResponseDto.of(getMarathonPublicCourses);
+
+    }
 
     public SearchPublicCourseResponseDto searchPublicCourse(Long userId, String keyword){
         //1. 받은 userId가 유저가 존재하는지 확인


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
close #88 

### 🤔 어떻게 이슈를 해결했나요?

---

- 메인화면에 고정으로 띄울 마라톤 코스 아이디들을 applicaton.yaml에 추가
- publicCourseService 빈이 만들어질때 applicaton.yaml에서 가져와 필드값으로 저장
- 가져온 코스들을 response

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
