### PR TITLE
[Fix] 유저 프로필에서 scrap 정보를 올바르게 가져온다.

### DIFF
--- a/src/main/java/org/runnect/server/course/repository/CourseRepository.java
+++ b/src/main/java/org/runnect/server/course/repository/CourseRepository.java
@@ -25,7 +25,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("select c from Course c join fetch c.runnectUser where c.runnectUser.id = :userId and c.isPrivate = true and c.deletedAt = null order by c.createdAt desc")
     List<Course> findCourseByUserIdOnlyPrivate(@Param("userId") Long userId);
 
-    @Query("select c from Course c where c.runnectUser = :runnectUser and c.isPrivate = false and c.deletedAt = null order by c.createdAt desc")
+    @Query("select c from Course c join fetch c.publicCourse where c.runnectUser = :runnectUser and c.isPrivate = false and c.deletedAt = null order by c.createdAt desc")
     List<Course> findCoursesForUserProfile(@Param("runnectUser") RunnectUser runnectUser);
 
     List<Course> findCoursesByRunnectUserAndIsPrivateIsFalseAndDeletedAtIsNull(RunnectUser runnectUser);

--- a/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
+++ b/src/main/java/org/runnect/server/scrap/repository/ScrapRepository.java
@@ -25,6 +25,9 @@ public interface ScrapRepository extends Repository<Scrap, Long> {
 
     Boolean existsByPublicCourseAndRunnectUser(PublicCourse publicCourse, RunnectUser runnectUser);
 
+    @Query("select s.publicCourse.id from Scrap s where s.runnectUser = :runnectUser and s.scrapTF = true")
+    List<Long> getScrappedTruePublicCourseIds(@Param("runnectUser") RunnectUser runnectUser);
+
     // DELETE
     Long deleteByPublicCourseIn(Collection<PublicCourse> publicCourses);
 

--- a/src/main/java/org/runnect/server/user/service/UserService.java
+++ b/src/main/java/org/runnect/server/user/service/UserService.java
@@ -7,16 +7,15 @@ import org.runnect.server.auth.service.AppleSignInService;
 import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.exception.UnauthorizedException;
 import org.runnect.server.course.repository.CourseRepository;
-import org.runnect.server.user.dto.request.UpdateUserNicknameRequestDto;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.scrap.repository.ScrapRepository;
+import org.runnect.server.user.dto.request.UpdateUserNicknameRequestDto;
+import org.runnect.server.user.dto.response.DeleteUserResponseDto;
 import org.runnect.server.user.dto.response.MyPageResponseDto;
 import org.runnect.server.user.dto.response.UpdateUserNicknameResponseDto;
 import org.runnect.server.user.dto.response.UserProfileResponseDto;
 import org.runnect.server.user.dto.response.UserProfileResponseDto.PublicCourseResponse;
 import org.runnect.server.user.dto.response.UserProfileResponseDto.UserProfile;
-import org.runnect.server.user.dto.response.DeleteUserResponseDto;
-
 import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.entity.SocialType;
 import org.runnect.server.user.exception.userException.DuplicateNicknameException;
@@ -72,13 +71,15 @@ public class UserService {
             .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
                 ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
+        List<Long> scrappedPublicCourseIds = scrapRepository.getScrappedTruePublicCourseIds(requestUser);
+
         List<PublicCourse> publicCourses = courseRepository.findCoursesForUserProfile(profileUser)
                 .stream().map(course -> course.getPublicCourse()).collect(Collectors.toList());
 
         List<PublicCourseResponse> publicCourseResponses = publicCourses.stream()
             .map(publicCourse ->
                 PublicCourseResponse.of(publicCourse, publicCourse.getCourse(),
-                    scrapRepository.existsByPublicCourseAndRunnectUser(publicCourse, requestUser)))
+                    scrappedPublicCourseIds.contains(publicCourse.getId())))
             .collect(Collectors.toList());
 
         return UserProfileResponseDto.of(userProfile, publicCourseResponses);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
close #132 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- 사용자가 스크랩한 publicCourseId List를 가져와서 contains() 함수 사용하는 것으로 수정한다.

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
