### PR TITLE
[Fix] createAndDeleteScrap시 스크랩 전체 개수도 반환

### DIFF
--- a/src/main/java/org/runnect/server/scrap/controller/ScrapController.java
+++ b/src/main/java/org/runnect/server/scrap/controller/ScrapController.java
@@ -21,12 +21,10 @@ public class ScrapController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto createAndDeleteScrap(@UserId Long userId, @RequestBody @Valid final CreateAndDeleteScrapRequestDto request) {
 
-        scrapService.createAndDeleteScrap(userId, request);
-
         if (request.getScrapTF() == true) {
-            return ApiResponseDto.success(SuccessStatus.CREATE_SCRAP_SUCCESS);
+            return ApiResponseDto.success(SuccessStatus.CREATE_SCRAP_SUCCESS, scrapService.createAndDeleteScrap(userId, request));
         }
-        return ApiResponseDto.success(SuccessStatus.DELETE_SCRAP_SUCCESS);
+        return ApiResponseDto.success(SuccessStatus.DELETE_SCRAP_SUCCESS, scrapService.createAndDeleteScrap(userId, request));
     }
 
     @GetMapping("scrap/user")

--- a/src/main/java/org/runnect/server/scrap/dto/response/CreateAndDeleteScrapDto.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/CreateAndDeleteScrapDto.java
@@ -1,0 +1,17 @@
+package org.runnect.server.scrap.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateAndDeleteScrapDto {
+    private Long scrapCount;
+
+    public static CreateAndDeleteScrapDto of (Long scrapCount) {
+        return new CreateAndDeleteScrapDto(scrapCount);
+    }
+}

--- a/src/main/java/org/runnect/server/scrap/dto/response/CreateAndDeleteScrapResponseDto.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/CreateAndDeleteScrapResponseDto.java
@@ -8,10 +8,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CreateAndDeleteScrapDto {
+public class CreateAndDeleteScrapResponseDto {
     private Long scrapCount;
 
-    public static CreateAndDeleteScrapDto of (Long scrapCount) {
-        return new CreateAndDeleteScrapDto(scrapCount);
+    public static CreateAndDeleteScrapResponseDto of (Long scrapCount) {
+        return new CreateAndDeleteScrapResponseDto(scrapCount);
     }
 }

--- a/src/main/java/org/runnect/server/scrap/service/ScrapService.java
+++ b/src/main/java/org/runnect/server/scrap/service/ScrapService.java
@@ -29,7 +29,7 @@ public class ScrapService {
     private final UserStampService userStampService;
 
     @Transactional
-    public CreateAndDeleteScrapDto createAndDeleteScrap(Long userId, CreateAndDeleteScrapRequestDto request) {
+    public CreateAndDeleteScrapResponseDto createAndDeleteScrap(Long userId, CreateAndDeleteScrapRequestDto request) {
         Scrap scrap = scrapRepository.findByUserIdAndPublicCourseId(userId, request.getPublicCourseId()).orElse(null);
         RunnectUser user = userRepository.findById(userId).orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
         PublicCourse publicCourse = publicCourseRepository.findById(request.getPublicCourseId())
@@ -61,7 +61,7 @@ public class ScrapService {
         // 해당 public course의 전체 스크랩 개수
         Long scrapCount = scrapRepository.countByPublicCourseAndScrapTFIsTrue(publicCourse);
 
-        return CreateAndDeleteScrapDto.of(scrapCount);
+        return CreateAndDeleteScrapResponseDto.of(scrapCount);
     }
 
     public GetScrapCourseResponseDto getScrapCourseByUser(Long userId) {

--- a/src/main/java/org/runnect/server/scrap/service/ScrapService.java
+++ b/src/main/java/org/runnect/server/scrap/service/ScrapService.java
@@ -8,10 +8,7 @@ import org.runnect.server.common.exception.NotFoundException;
 import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.publicCourse.repository.PublicCourseRepository;
 import org.runnect.server.scrap.dto.request.CreateAndDeleteScrapRequestDto;
-import org.runnect.server.scrap.dto.response.DepartureResponse;
-import org.runnect.server.scrap.dto.response.GetScrapCourseResponseDto;
-import org.runnect.server.scrap.dto.response.ScrapResponse;
-import org.runnect.server.scrap.dto.response.UserResponse;
+import org.runnect.server.scrap.dto.response.*;
 import org.runnect.server.scrap.entity.Scrap;
 import org.runnect.server.scrap.repository.ScrapRepository;
 import org.runnect.server.user.entity.RunnectUser;
@@ -32,15 +29,15 @@ public class ScrapService {
     private final UserStampService userStampService;
 
     @Transactional
-    public void createAndDeleteScrap(Long userId, CreateAndDeleteScrapRequestDto request) {
+    public CreateAndDeleteScrapDto createAndDeleteScrap(Long userId, CreateAndDeleteScrapRequestDto request) {
         Scrap scrap = scrapRepository.findByUserIdAndPublicCourseId(userId, request.getPublicCourseId()).orElse(null);
         RunnectUser user = userRepository.findById(userId).orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        PublicCourse publicCourse = publicCourseRepository.findById(request.getPublicCourseId())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_PUBLICCOURSE_EXCEPTION, ErrorStatus.NOT_FOUND_PUBLICCOURSE_EXCEPTION.getMessage()));
         // 스크랩 생성
         if (request.getScrapTF() == true) {
             if (scrap == null) {
                 // 기존 스크랩한 내역이 없을 때
-                PublicCourse publicCourse = publicCourseRepository.findById(request.getPublicCourseId())
-                        .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_PUBLICCOURSE_EXCEPTION, ErrorStatus.NOT_FOUND_PUBLICCOURSE_EXCEPTION.getMessage()));
                 Scrap newScrap = Scrap.builder()
                         .scrapTF(true)
                         .publicCourse(publicCourse)
@@ -60,6 +57,11 @@ public class ScrapService {
         else {
             scrap.updateScrapTF(false);
         }
+
+        // 해당 public course의 전체 스크랩 개수
+        Long scrapCount = scrapRepository.countByPublicCourseAndScrapTFIsTrue(publicCourse);
+
+        return CreateAndDeleteScrapDto.of(scrapCount);
     }
 
     public GetScrapCourseResponseDto getScrapCourseByUser(Long userId) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #134 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- scrap할 public course를 넘겨주고, 해당 public course가 스크랩된 횟수를 count해 넘겨줌(scrapRepository)

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
