### PR TITLE
[Feat] 내가 그린 코스 조회 시 distance도 함께 반환

### DIFF
--- a/src/main/java/org/runnect/server/course/dto/response/CourseResponse.java
+++ b/src/main/java/org/runnect/server/course/dto/response/CourseResponse.java
@@ -15,12 +15,13 @@ public class CourseResponse {
     private Long id;
     private String image;
     private LocalDateTime createdAt;
+    private Float distance;
     private String title;
     private DepartureResponse departure;
 
-    public static CourseResponse of(Long id, String image, LocalDateTime createdAt, String title,
-        DepartureResponse departure) {
-        return new CourseResponse(id, image, createdAt, title, departure);
+    public static CourseResponse of(Long id, String image, LocalDateTime createdAt, Float distance,
+        String title, DepartureResponse departure) {
+        return new CourseResponse(id, image, createdAt, distance, title, departure);
     }
 
 }

--- a/src/main/java/org/runnect/server/course/service/CourseService.java
+++ b/src/main/java/org/runnect/server/course/service/CourseService.java
@@ -83,6 +83,7 @@ public class CourseService {
                 course.getId(),
                 course.getImage(),
                 course.getCreatedAt(),
+                course.getDistance(),
                 course.getTitle(),
                 DepartureResponse.from(course)
             )).collect(Collectors.toList());
@@ -103,6 +104,7 @@ public class CourseService {
                 course.getId(),
                 course.getImage(),
                 course.getCreatedAt(),
+                course.getDistance(),
                 course.getTitle(),
                 DepartureResponse.from(course)
             )).collect(Collectors.toList());


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #140 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- response dto에 distance 필드 추가
- 서비스단에서 distance도 함께 넘겨준다.

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
