### PR TITLE
[Fix] createAndDeleteScrap API 반환값 변경(#142)

### DIFF
--- a/src/main/java/org/runnect/server/scrap/dto/response/CreateAndDeleteScrapResponseDto.java
+++ b/src/main/java/org/runnect/server/scrap/dto/response/CreateAndDeleteScrapResponseDto.java
@@ -9,9 +9,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateAndDeleteScrapResponseDto {
-    private Long scrapCount;
 
-    public static CreateAndDeleteScrapResponseDto of (Long scrapCount) {
-        return new CreateAndDeleteScrapResponseDto(scrapCount);
+    private Long publicCourseId;
+    private Long scrapCount;
+    private Boolean scrapTF;
+
+    public static CreateAndDeleteScrapResponseDto of (Long publicCourseId, Long scrapCount, Boolean scrapTF) {
+        return new CreateAndDeleteScrapResponseDto(publicCourseId, scrapCount, scrapTF);
     }
 }

--- a/src/main/java/org/runnect/server/scrap/service/ScrapService.java
+++ b/src/main/java/org/runnect/server/scrap/service/ScrapService.java
@@ -61,7 +61,7 @@ public class ScrapService {
         // 해당 public course의 전체 스크랩 개수
         Long scrapCount = scrapRepository.countByPublicCourseAndScrapTFIsTrue(publicCourse);
 
-        return CreateAndDeleteScrapResponseDto.of(scrapCount);
+        return CreateAndDeleteScrapResponseDto.of(request.getPublicCourseId(), scrapCount, request.getScrapTF());
     }
 
     public GetScrapCourseResponseDto getScrapCourseByUser(Long userId) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #142 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- request로 받은 scrapTF와 publicCourseId를 response dto에 포함하여 반환
-

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
