### PR TITLE
[Feat] Swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	// Sentry
 	implementation 'io.sentry:sentry-spring-boot-starter:4.3.0'
 
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/runnect/server/auth/controller/AuthController.java
+++ b/src/main/java/org/runnect/server/auth/controller/AuthController.java
@@ -3,6 +3,8 @@ package org.runnect.server.auth.controller;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.auth.dto.request.SignInRequestDto;
 import org.runnect.server.auth.dto.response.AuthResponseDto;
@@ -19,12 +21,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 @Validated
+@Tag(name = "Auth", description = "Auth API Document")
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Social Login & Sign Up", description = "소셜 로그인 및 회원가입")
     public ApiResponseDto<AuthResponseDto> signIn(@Valid @RequestBody SignInRequestDto requestDto) {
         AuthResponseDto result = authService.signIn(requestDto);
         if(result.getClass().equals(SignInResponseDto.class)){
@@ -39,6 +43,7 @@ public class AuthController {
 
     @GetMapping("/getNewToken")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getNewToken", description = "accessToken 재발급")
     public ApiResponseDto<GetNewTokenResponseDto> getNewToken(@RequestHeader @NotBlank String accessToken,
                                                               @RequestHeader @NotBlank String refreshToken){
 

--- a/src/main/java/org/runnect/server/auth/dto/response/SignInResponseDto.java
+++ b/src/main/java/org/runnect/server/auth/dto/response/SignInResponseDto.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignInResponseDto implements AuthResponseDto{
-
     private String type;
     private String email;
     private String accessToken;

--- a/src/main/java/org/runnect/server/auth/dto/response/SignUpResponseDto.java
+++ b/src/main/java/org/runnect/server/auth/dto/response/SignUpResponseDto.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignUpResponseDto implements AuthResponseDto{
-
     private String type;
     private String email;
     private String nickname;

--- a/src/main/java/org/runnect/server/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/runnect/server/config/swagger/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package org.runnect.server.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Runnect Springboot Server Swagger")
+                .description("Runnect API document🏃🏻‍♀️")
+                .version("1.0.0");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}

--- a/src/main/java/org/runnect/server/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/runnect/server/config/swagger/SwaggerConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()

--- a/src/main/java/org/runnect/server/course/controller/CourseController.java
+++ b/src/main/java/org/runnect/server/course/controller/CourseController.java
@@ -1,6 +1,9 @@
 package org.runnect.server.course.controller;
 
 import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.runnect.server.common.constant.SuccessStatus;
@@ -34,6 +37,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/course")
+@Tag(name = "Course", description = "Course API Document")
 public class CourseController {
 
     private final S3Service s3Service;
@@ -41,6 +45,7 @@ public class CourseController {
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE}, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "createCourse", description = "경로 그리기")
     public ApiResponseDto<CourseCreateResponseDto> createCourse(
         @UserId Long userId,
         @RequestPart @Valid final CourseCreateRequestDto data,
@@ -53,6 +58,7 @@ public class CourseController {
 
     @GetMapping("/user")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getCourseByUser", description = "내가 그린 코스(업로드 포함)")
     public ApiResponseDto<CourseGetByUserResponseDto> getCourseByUser(@UserId Long userId) {
         return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER_SUCCESS,
             courseService.getCourseByUser(userId));
@@ -60,6 +66,7 @@ public class CourseController {
 
     @GetMapping("/private/user")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getPrivateCourseByUser", description = "내가 그린 코스(업로드 미포함)")
     public ApiResponseDto<CourseGetByUserResponseDto> getPrivateCourseByUser(
         @UserId Long userId) {
         return ApiResponseDto.success(SuccessStatus.GET_COURSE_LIST_BY_USER_SUCCESS,
@@ -68,6 +75,7 @@ public class CourseController {
 
     @GetMapping("/detail/{courseId}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getCourseDetail", description = "내가 그린 코스 상세 페이지와 달리기, 러닝 기록 작성 뷰")
     public ApiResponseDto<GetCourseDetailResponseDto> getCourseDetail(@UserId Long userId,
         @PathVariable Long courseId) {
         return ApiResponseDto.success(SuccessStatus.GET_COURSE_DETAIL_SUCCESS,
@@ -76,6 +84,7 @@ public class CourseController {
 
     @PatchMapping("/{courseId}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "updateCourse", description = "내가 그린 코스 제목 수정")
     public ApiResponseDto<UpdateCourseResponseDto> updateCourse(@UserId Long userId,
         @PathVariable(name = "courseId") Long courseId,
         @RequestBody @Valid final UpdateCourseRequestDto request) {
@@ -85,6 +94,7 @@ public class CourseController {
 
     @PutMapping
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "deleteCourse", description = "코스 삭제")
     public ApiResponseDto<DeleteCoursesResponseDto> deleteCourses(
         @UserId Long userId,
         @Valid @RequestBody final DeleteCoursesRequestDto deleteCoursesRequestDto

--- a/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
+++ b/src/main/java/org/runnect/server/publicCourse/controller/PublicCourseController.java
@@ -5,6 +5,8 @@ import javax.validation.constraints.Positive;
 
 import javax.validation.constraints.NotBlank;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.constant.SuccessStatus;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/public-course")
+@Tag(name = "Public-Course", description = "Public Course API Document")
 public class PublicCourseController {
 
     private final PublicCourseService publicCourseService;
@@ -37,6 +40,7 @@ public class PublicCourseController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "recommendPublicCourse", description = "코스 발견 - 이런 코스는 어때요?")
     public ApiResponseDto<RecommendPublicCourseResponseDto> recommendPublicCourse(
             @UserId final Long userId,
             @RequestParam(required = false) @Positive Integer pageNo,
@@ -52,6 +56,7 @@ public class PublicCourseController {
 
     @GetMapping("/search")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "searchPublicCourse", description = "코스 검색")
     public ApiResponseDto<SearchPublicCourseResponseDto> searchPublicCourse(
             @UserId final Long userId,
             @RequestParam @NotBlank String keyword
@@ -63,6 +68,7 @@ public class PublicCourseController {
 
     @GetMapping("/marathon")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getMarathonPublicCourse", description = "코스 발견 - 마라톤 코스")
     public ApiResponseDto<GetMarathonPublicCourseResponseDto> getMarathonPublicCourse(
             @UserId final Long userId
     ){
@@ -74,6 +80,7 @@ public class PublicCourseController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "createPublicCourse", description = "내가 그린 코스 업로드 하기")
     public ApiResponseDto<CreatePublicCourseResponseDto> createPublicCourse(
             //TODO : 임시로 개발후 테스트완료하면 다시
             @UserId final Long userId,
@@ -86,6 +93,7 @@ public class PublicCourseController {
 
     @GetMapping("/detail/{publicCourseId}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getPublicCourseDetail", description = "업로드된 코스 (스크랩 코스, 추천 코스) 상세페이지와 달리기, 러닝기록 작성 뷰")
     public ApiResponseDto<GetPublicCourseDetailResponseDto> getPublicCourseDetail(
             @UserId final Long userId,
             @PathVariable final Long publicCourseId
@@ -97,6 +105,7 @@ public class PublicCourseController {
 
     @GetMapping("/user")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getPublicCourseByUser", description = "유저가 업로드 한 코스")
     public ApiResponseDto<GetPublicCourseByUserResponseDto> getPublicCourseByUser(
             // TODO : 테스트 후
             @UserId final Long userId
@@ -110,6 +119,7 @@ public class PublicCourseController {
 
     @GetMapping("/total-page-count")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getPublicCourseTotalPageCount", description = "코스발견 - 이런 코스는 어때요?의 코스 전체 개수")
     public ApiResponseDto<GetPublicCourseTotalPageCountResponseDto> getPublicCourseTotalPageCount(){
         return ApiResponseDto.success(SuccessStatus.GET_PUBLIC_COURSE_TOTAL_PAGE_COUNT_SUCCESS,
                 publicCourseService.getPublicCourseTotalPageCount());
@@ -118,6 +128,7 @@ public class PublicCourseController {
 
     @PutMapping
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "deletePublicCourse", description = "업로드 한 코스 삭제")
     public ApiResponseDto<DeletePublicCoursesResponseDto> deletePublicCourses(
         @UserId final Long userId,
         @Valid @RequestBody final DeletePublicCoursesRequestDto deletePublicCoursesRequestDto
@@ -128,6 +139,7 @@ public class PublicCourseController {
 
     @PatchMapping("/{publicCourseId}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "updatePublicCourse", description = "퍼블릭 코스 제목, 설명수정")
     public ApiResponseDto<UpdatePublicCourseResponseDto> updatePublicCourse(
             @UserId Long userId, @PathVariable(name = "publicCourseId") Long publicCourseId,
             @RequestBody @Valid final UpdatePublicCourseRequestDto request)  {

--- a/src/main/java/org/runnect/server/record/controller/RecordController.java
+++ b/src/main/java/org/runnect/server/record/controller/RecordController.java
@@ -1,6 +1,9 @@
 package org.runnect.server.record.controller;
 
 import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.constant.SuccessStatus;
 import org.runnect.server.common.dto.ApiResponseDto;
@@ -27,11 +30,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "Record", description = "Record API Document")
 public class RecordController {
     private final RecordService recordService;
 
     @PostMapping("record")
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "createRecord", description = "러닝기록하기")
     public ApiResponseDto<CreateRecordResponseDto> createRecord(@UserId Long userId, @RequestBody @Valid final CreateRecordRequestDto request) {
 
         return ApiResponseDto.success(SuccessStatus.CREATE_RECORD_SUCCESS, recordService.createRecord(userId, request));
@@ -39,18 +44,21 @@ public class RecordController {
 
     @GetMapping("record/user")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getRecordByUser", description = "유저 러닝 기록")
     public ApiResponseDto<GetRecordResponseDto> getRecordByUser(@UserId Long userId) {
         return ApiResponseDto.success(SuccessStatus.GET_RECORD_SUCCESS, recordService.getRecordByUser(userId));
     }
 
     @PatchMapping("record/{recordId}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "updateRecord", description = "러닝기록 제목 수정")
     public ApiResponseDto<UpdateRecordResponseDto> updateRecord(@UserId Long userId, @PathVariable(name = "recordId") Long recordId, @RequestBody @Valid final UpdateRecordRequestDto request) {
         return ApiResponseDto.success(SuccessStatus.UPDATE_RECORD_SUCCESS, recordService.updateRecord(userId, recordId, request));
     }
 
     @PutMapping("record")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "deleteRecord", description = "러닝기록삭제")
     public ApiResponseDto<DeleteRecordsResponseDto> deleteRecords(
         @UserId Long userId,
         @Valid @RequestBody DeleteRecordsRequestDto requestDto

--- a/src/main/java/org/runnect/server/scrap/controller/ScrapController.java
+++ b/src/main/java/org/runnect/server/scrap/controller/ScrapController.java
@@ -1,5 +1,7 @@
 package org.runnect.server.scrap.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.constant.SuccessStatus;
@@ -15,10 +17,12 @@ import javax.validation.Valid;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "Scrap", description = "Scrap API Document")
 public class ScrapController {
     private final ScrapService scrapService;
     @PostMapping("scrap")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "createAndDeleteScrap", description = "코스 스크랩, 스크랩 취소")
     public ApiResponseDto createAndDeleteScrap(@UserId Long userId, @RequestBody @Valid final CreateAndDeleteScrapRequestDto request) {
 
         if (request.getScrapTF() == true) {
@@ -29,6 +33,7 @@ public class ScrapController {
 
     @GetMapping("scrap/user")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getScrapCourseByUser", description = "내가 스크랩한 코스")
     public ApiResponseDto<GetScrapCourseResponseDto> getScrapCourseByUser(@UserId Long userId) {
         return ApiResponseDto.success(SuccessStatus.GET_SCRAP_COURSE_BY_USER_SUCCESS, scrapService.getScrapCourseByUser(userId));
     }

--- a/src/main/java/org/runnect/server/user/controller/UserController.java
+++ b/src/main/java/org/runnect/server/user/controller/UserController.java
@@ -3,6 +3,8 @@ package org.runnect.server.user.controller;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.constant.SuccessStatus;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
+@Tag(name = "User", description = "User API Document")
 public class UserController {
 
     private final UserService userService;
@@ -26,6 +29,7 @@ public class UserController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getMyPage", description = "마이페이지 조회")
     public ApiResponseDto<MyPageResponseDto> getMyPage(@UserId Long userId) {
         return ApiResponseDto.success(
             SuccessStatus.GET_MY_PAGE_SUCCESS, userService.getMyPage(userId));
@@ -33,6 +37,7 @@ public class UserController {
 
     @PatchMapping
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "updateUserNickname", description = "닉네임 변경")
     public ApiResponseDto<UpdateUserNicknameResponseDto> updateUserNickname(
         @UserId Long userId,
         @Valid @RequestBody UpdateUserNicknameRequestDto updateUserNicknameRequestDto
@@ -43,6 +48,7 @@ public class UserController {
 
     @GetMapping("/{profileUserId}")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getUserProfile", description = "유저 프로필 조회")
     public ApiResponseDto<UserProfileResponseDto> getUserProfile(
         @UserId Long userId,
         @PathVariable Long profileUserId
@@ -53,6 +59,7 @@ public class UserController {
 
     @DeleteMapping
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "deleteUser", description = "회원 탈퇴")
     public ApiResponseDto<DeleteUserResponseDto> deleteUser(
             @UserId Long userId,
             @RequestHeader(required = false) @NotBlank String appleAccessToken

--- a/src/main/java/org/runnect/server/user/controller/UserStampController.java
+++ b/src/main/java/org/runnect/server/user/controller/UserStampController.java
@@ -2,6 +2,8 @@ package org.runnect.server.user.controller;
 
 import static org.runnect.server.common.constant.SuccessStatus.GET_USER_STAMPS_SUCCESS;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.resolver.userId.UserId;
@@ -16,12 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/stamp")
+@Tag(name = "Stamp", description = "Stamp API Document")
 public class UserStampController {
 
     private final UserStampService userStampService;
 
     @GetMapping("/user")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "getStampByUser", description = "유저 목표 보상(유저가 받은 스탬프)")
     public ApiResponseDto<GetUserStampsResponseDto> getUserStamps(
         @UserId Long userId
     ) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #155 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- <!-- 실제로 해결한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->
-

### 🤯 주의할 점이 있나요?

---
![image](https://github.com/Runnect/Runnect-Spring-Boot-Server/assets/87180069/fe8a8eb2-2ed8-46be-9507-a2c75fb3c2e5)
- api 호출 시 헤더에 accessToken, refreshToken을 받아서 이를 userId를 변환하여 이용하잖아용! 
근데 이게 코드상으로는 파라미터로 userId를 받는 것으로 되어있어 저렇게 모든 api의 request에 userId가 포함되어있어요 ㅠ
swagger에서 jwt적용, 전역 파라미터 적용 등등.. 여러 시도를 해봤는데 잘 안돼서 혹시 다른 프로젝트에서는 해당 문제를 어떻게 해결했는지 궁금합니다!!

- 현재 노션 명세서 상에서는 다양한 에러 처리 예시를 보여주고 있는데, 이를 swagger에서 표현하려면 코드에 작성을 해야 해서 좀 보기 안 좋을 것 같더라구용ㅠ 이것도 다른 프로젝트에서는 어떻게 하셨는지 궁금합니다!! 
