### PR TITLE
[Fix] - 공개 코스 삭제 시 FK 제약 위반 수정

### DIFF
--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -361,6 +361,9 @@ public class PublicCourseService {
                             ErrorStatus.PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION.getMessage());
                 });
 
+        //삭제전 연관된 스크랩 먼저 삭제
+        scrapRepository.deleteByPublicCourseIn(publicCourses);
+
         //삭제전 course의 isPrivate update
         publicCourses.forEach(publicCourse -> publicCourse.getCourse().retrieveCourse());
 


### PR DESCRIPTION
### 😶 무슨 이슈인가요?

---

관리자가 타인의 공개 코스를 삭제할 때 500 Internal Server Error 발생.
`deleteAllInBatch`가 JPA cascade를 무시하고 직접 SQL DELETE를 실행하여, `Scrap` 테이블의 FK 제약 조건 위반.

### 🤔 어떻게 이슈를 해결했나요?

---

- `publicCourseRepository.deleteAllInBatch()` 호출 전에 `scrapRepository.deleteByPublicCourseIn(publicCourses)` 추가
- 이미 `ScrapRepository`에 정의되어 있던 메서드를 활용 (신규 코드 없음)
- 삭제 순서: 스크랩 삭제 → isPrivate 업데이트 → 공개 코스 삭제

### 🤯 주의할 점이 있나요?

---

- 이 버그는 관리자뿐 아니라, 스크랩된 코스를 소유자가 삭제할 때도 동일하게 발생할 수 있었던 잠재적 버그인 것 같네용
- `deleteAllInBatch`는 JPA lifecycle callback과 cascade를 무시하므로 연관 엔티티를 수동으로 먼저 삭제해야 합니다!