### PR TITLE
[Fix] - 공개 코스 삭제 시 FK 제약 위반 수정 (dev → main)

### DIFF
--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -361,6 +361,9 @@ public class PublicCourseService {
                             ErrorStatus.PERMISSION_DENIED_PUBLIC_COURSE_DELETE_EXCEPTION.getMessage());
                 });
 
+        //삭제전 연관된 스크랩 먼저 삭제
+        scrapRepository.deleteByPublicCourseIn(publicCourses);
+
         //삭제전 course의 isPrivate update
         publicCourses.forEach(publicCourse -> publicCourse.getCourse().retrieveCourse());
 


### PR DESCRIPTION
### 😶 무슨 이슈인가요?

---

dev → main 머지 (프로덕션 배포)
공개 코스 삭제 시 Scrap FK 제약 위반 500 에러 수정 반영 (#170)

### 🤔 어떻게 이슈를 해결했나요?

---

- #170 에서 공개 코스 삭제 전 연관 스크랩 먼저 삭제하도록 수정
- dev → main 머지로 프로덕션 자동 배포 트리거

### 🤯 주의할 점이 있나요?

---

- main push 시 GitHub Actions → S3 → CodeDeploy 무중단 배포 자동 실행
- 서버분들 CI/CD 파이프라인 너무 잘 구축해주셔서 편하게 배포할 수 있었습니다 감사합니다 ~^^