### PR TITLE
[Fix] - 공개 코스 삭제 시 Record FK null 처리 추가

### DIFF
--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -14,6 +14,7 @@ import org.runnect.server.common.exception.PermissionDeniedException;
 import org.runnect.server.common.module.convert.CoordinatePathConverter;
 import org.runnect.server.course.entity.Course;
 import org.runnect.server.course.repository.CourseRepository;
+import org.runnect.server.record.repository.RecordRepository;
 import org.runnect.server.publicCourse.dto.request.CreatePublicCourseRequestDto;
 import org.runnect.server.publicCourse.dto.request.DeletePublicCoursesRequestDto;
 import org.runnect.server.publicCourse.dto.response.CreatePublicCourseResponseDto;
@@ -53,6 +54,7 @@ public class PublicCourseService {
     private final UserRepository userRepository;
     private final ScrapRepository scrapRepository;
     private final CourseRepository courseRepository;
+    private final RecordRepository recordRepository;
 
 
     @Value("${runnect.marathon-public-course-id}")
@@ -363,6 +365,9 @@ public class PublicCourseService {
 
         //삭제전 연관된 스크랩 먼저 삭제
         scrapRepository.deleteByPublicCourseIn(publicCourses);
+
+        //삭제전 연관된 Record의 publicCourse FK null 처리
+        recordRepository.nullifyPublicCourseIn(publicCourses);
 
         //삭제전 course의 isPrivate update
         publicCourses.forEach(publicCourse -> publicCourse.getCourse().retrieveCourse());

--- a/src/main/java/org/runnect/server/record/repository/RecordRepository.java
+++ b/src/main/java/org/runnect/server/record/repository/RecordRepository.java
@@ -1,8 +1,10 @@
 package org.runnect.server.record.repository;
 
 import java.util.Collection;
+import org.runnect.server.publicCourse.entity.PublicCourse;
 import org.runnect.server.record.entity.Record;
 import org.runnect.server.user.entity.RunnectUser;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -29,4 +31,8 @@ public interface RecordRepository extends Repository<Record, Long> {
 
     // DELETE
     long deleteByIdIn(Collection<Long> ids);
+
+    @Modifying
+    @Query("UPDATE Record r SET r.publicCourse = null WHERE r.publicCourse IN :publicCourses")
+    int nullifyPublicCourseIn(@Param("publicCourses") Collection<PublicCourse> publicCourses);
 }


### PR DESCRIPTION
### 😶 무슨 이슈인가요?
---
관리자가 타인의 공개 코스 삭제 시 Record 테이블의 public_course_id FK 제약 위반으로 500 에러 발생.
기존 스크랩 삭제 처리(#170)에 이어 Record FK null 처리가 누락되어 있었음.

### 🤔 어떻게 이슈를 해결했나요?
---
- RecordRepository에 @Modifying @Query로 벌크 UPDATE 메서드 추가 (nullifyPublicCourseIn)
- PublicCourseService.deletePublicCourses()에서 PublicCourse 삭제 전 Record.publicCourse를 null로 업데이트
- 삭제 순서: 스크랩 삭제 → Record FK null → isPrivate 업데이트 → PublicCourse 삭제

### 🤯 주의할 점이 있나요?
---
- 서버 노션 문서의 삭제 정책과 일치: "publicCourse에 연결된 record → publicCourse가 null인 상태로 유지"
- Record.setPublicCourseNull() 엔티티 메서드가 이미 존재했지만 호출되지 않고 있었음
- 벌크 UPDATE로 처리하여 대량 Record도 단일 쿼리로 효율적 처리