### PR TITLE
[Fix] - GET /api/health/summary 500 에러 수정

### DIFF
--- a/src/main/java/org/runnect/server/health/repository/RecordHealthDataRepository.java
+++ b/src/main/java/org/runnect/server/health/repository/RecordHealthDataRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface RecordHealthDataRepository extends Repository<RecordHealthData, Long> {
@@ -27,7 +28,7 @@ public interface RecordHealthDataRepository extends Repository<RecordHealthData,
             "COALESCE(SUM(h.zone5Seconds), 0) " +
             "FROM Record r LEFT JOIN RecordHealthData h ON r.id = h.record.id " +
             "WHERE r.runnectUser.id = :userId AND r.createdAt >= :startDate AND r.createdAt < :endDate")
-    Object[] getHealthSummary(@Param("userId") Long userId,
-                              @Param("startDate") LocalDateTime startDate,
-                              @Param("endDate") LocalDateTime endDate);
+    List<Object[]> getHealthSummary(@Param("userId") Long userId,
+                                    @Param("startDate") LocalDateTime startDate,
+                                    @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/org/runnect/server/health/service/HealthService.java
+++ b/src/main/java/org/runnect/server/health/service/HealthService.java
@@ -153,7 +153,8 @@ public class HealthService {
         LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
 
         // 3. 통계 쿼리 실행
-        Object[] result = recordHealthDataRepository.getHealthSummary(userId, startDateTime, endDateTime);
+        List<Object[]> results = recordHealthDataRepository.getHealthSummary(userId, startDateTime, endDateTime);
+        Object[] result = results.isEmpty() ? new Object[10] : results.get(0);
 
         Long totalRecords = result[0] != null ? ((Number) result[0]).longValue() : 0L;
         Long recordsWithHealth = result[1] != null ? ((Number) result[1]).longValue() : 0L;


### PR DESCRIPTION
### 🔨 무슨 이슈인가요?
---
PR #178: GET /api/health/summary 500 에러 핫픽스

### 🛠 어떻게 이슈를 해결했나요?
---
- aggregate 쿼리 리턴 타입 수정 (Object[] → List<Object[]>)

### ⚠️ 주의할 점이 있나요?
---
- 기존 API 영향 없음