### PR TITLE
[Fix] - 배포 안정성 강화: 에러 핸들러 연쇄 장애 방지

### DIFF
--- a/src/main/java/org/runnect/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/org/runnect/server/common/advice/ControllerExceptionAdvice.java
@@ -1,7 +1,6 @@
 package org.runnect.server.common.advice;
 
 import io.sentry.Sentry;
-import java.io.IOException;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
@@ -10,6 +9,7 @@ import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.dto.ApiResponseDto;
 import org.runnect.server.common.exception.BasicException;
 import org.runnect.server.config.slack.SlackApi;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 @Component
 @RequiredArgsConstructor
@@ -71,9 +72,17 @@ public class ControllerExceptionAdvice {
      */
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
-    protected ApiResponseDto<Object> handleException(final Exception error, final HttpServletRequest request) throws IOException {
-        slackApi.sendAlert(error, request);
-        Sentry.captureException(error);
+    protected ApiResponseDto<Object> handleException(final Exception error, final HttpServletRequest request) {
+        try {
+            slackApi.sendAlert(error, request);
+        } catch (Exception e) {
+            log.error("Slack 알림 전송 실패", e);
+        }
+        try {
+            Sentry.captureException(error);
+        } catch (Exception e) {
+            log.error("Sentry 전송 실패", e);
+        }
         return ApiResponseDto.error(ErrorStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/org/runnect/server/config/slack/SlackApi.java
+++ b/src/main/java/org/runnect/server/config/slack/SlackApi.java
@@ -27,8 +27,6 @@ public class SlackApi {
     private final static String NEW_LINE = "\n";
     private final static String DOUBLE_NEW_LINE = "\n\n";
 
-    private StringBuilder sb = new StringBuilder();
-
     public void sendAlert(Exception error, HttpServletRequest request) throws IOException {
 
         List<LayoutBlock> layoutBlocks = generateLayoutBlock(error, request);
@@ -53,7 +51,7 @@ public class SlackApi {
     }
 
     private String generateErrorMessage(Exception error) {
-        sb.setLength(0);
+        StringBuilder sb = new StringBuilder();
         sb.append("*[🔥 Exception]*" + NEW_LINE + error.toString() + DOUBLE_NEW_LINE);
         sb.append("*[📩 From]*" + NEW_LINE + readRootStackTrace(error) + DOUBLE_NEW_LINE);
 
@@ -61,7 +59,7 @@ public class SlackApi {
     }
 
     private String generateErrorPointMessage(HttpServletRequest request) {
-        sb.setLength(0);
+        StringBuilder sb = new StringBuilder();
         sb.append("*[🧾세부정보]*" + NEW_LINE);
         sb.append("Request URL : " + request.getRequestURL().toString() + NEW_LINE);
         sb.append("Request Method : " + request.getMethod() + NEW_LINE);
@@ -71,6 +69,9 @@ public class SlackApi {
     }
 
     private String readRootStackTrace(Exception error) {
+        if (error.getStackTrace() == null || error.getStackTrace().length == 0) {
+            return "Unknown";
+        }
         return error.getStackTrace()[0].toString();
     }
 

--- a/src/main/java/org/runnect/server/record/service/RecordService.java
+++ b/src/main/java/org/runnect/server/record/service/RecordService.java
@@ -110,10 +110,15 @@ public class RecordService {
 
             DepartureResponse departure = DepartureResponse.of(course.getDepartureRegion(), course.getDepartureCity());
 
-            // 건강 데이터 조회
-            HealthDataResponse healthData = recordHealthDataRepository.findByRecordId(record.getId())
-                    .map(h -> HealthDataResponse.of(h.getAvgHeartRate(), h.getCalories()))
-                    .orElse(null);
+            // 건강 데이터 조회 (실패해도 기록 목록은 정상 반환)
+            HealthDataResponse healthData = null;
+            try {
+                healthData = recordHealthDataRepository.findByRecordId(record.getId())
+                        .map(h -> HealthDataResponse.of(h.getAvgHeartRate(), h.getCalories()))
+                        .orElse(null);
+            } catch (Exception e) {
+                // 건강 데이터 테이블 미생성 등 예외 발생 시 무시
+            }
 
             RecordResponse recordResponse = RecordResponse.of(record.getId(), course.getId(), publicCourseId, userId,
                     record.getTitle(), course.getImage(), record.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")), course.getDistance(), record.getTime().toString(),


### PR DESCRIPTION
## Summary
- ControllerExceptionAdvice: Slack/Sentry 호출을 try-catch로 감싸서 에러 핸들러 자체가 터지는 연쇄 장애 방지
- SlackApi: StringBuilder 인스턴스 변수 → 지역 변수 (스레드 안전), 빈 스택트레이스 방어
- RecordService: 건강 데이터 조회 실패해도 기록 목록은 정상 반환

## 원인 분석
건강 데이터 테이블 쿼리 실패 → ControllerExceptionAdvice.handleException()에서 SlackApi.sendAlert() 호출 → sendAlert도 실패 (throws IOException 전파) → Spring 기본 500 포맷 반환 → 모든 500 에러가 연쇄적으로 깨짐

## 방어 포인트
1. **에러 핸들러 절대 안 터짐**: Slack/Sentry 실패해도 `ApiResponseDto` 정상 반환
2. **기존 기능 절대 안 깨짐**: health data 조회 실패해도 record 목록은 정상
3. **스레드 안전**: SlackApi의 공유 StringBuilder 제거

## Test plan
- [ ] `/api/record` 정상 응답 확인
- [ ] `/api/auth` 정상 응답 확인
- [ ] `/api/public-course` visitor 모드 정상 확인
- [ ] health data API 정상 동작 확인