### PR TITLE
[Fix] - deploy.sh 정상 복구 + Nginx 자동 재시작

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,6 +11,7 @@ echo "> 현재 구동중인 Set 확인"
 CURRENT_PROFILE=$(curl -s http://localhost/profile)
 echo "> $CURRENT_PROFILE"
 
+# 쉬고 있는 set 찾기: set1이 사용중이면 set2가 쉬고 있고, 반대면 set1이 쉬고 있음
 if [ $CURRENT_PROFILE == set1 ]
 then
   IDLE_PROFILE=set2
@@ -48,6 +49,7 @@ echo "> $IDLE_PROFILE 배포"
 nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=$IDLE_PROFILE $IDLE_APPLICATION_PATH >> /home/ubuntu/app/nohup.out 2>&1 &
 
 echo "> $IDLE_PROFILE 10초 후 Health check 시작"
+echo "> curl -s http://localhost:$IDLE_PORT/health "
 sleep 10
 
 for retry_count in {1..10}
@@ -56,59 +58,39 @@ do
   up_count=$(echo $response | grep 'UP' | wc -l)
 
   if [ $up_count -ge 1 ]
-  then
+  then # $up_count >= 1 ("UP" 문자열이 있는지 검증)
       echo "> Health check 성공"
       break
   else
       echo "> Health check의 응답을 알 수 없거나 혹은 status가 UP이 아닙니다."
+      echo "> Health check: ${response}"
   fi
 
   if [ $retry_count -eq 10 ]
   then
-    echo "> Health check 실패."
+    echo "> Health check 실패. "
+    echo "> Nginx에 연결하지 않고 배포를 종료합니다."
     exit 1
   fi
 
+  echo "> Health check 연결 실패. 재시도..."
   sleep 10
 done
 
-echo "> Nginx 복구"
-sudo systemctl stop nginx 2>/dev/null || true
-sleep 1
-sudo systemctl start nginx
-sleep 2
-
-echo "> 방화벽 초기화"
-sudo ufw disable 2>/dev/null || true
-sudo iptables -P INPUT ACCEPT 2>/dev/null || true
-sudo iptables -P FORWARD ACCEPT 2>/dev/null || true
-sudo iptables -P OUTPUT ACCEPT 2>/dev/null || true
-sudo iptables -F 2>/dev/null || true
+echo "> Nginx 상태 확인"
+if ! sudo systemctl is-active --quiet nginx; then
+  echo "> Nginx가 중지되어 있습니다. 재시작합니다."
+  sudo systemctl start nginx
+  sleep 2
+  if sudo systemctl is-active --quiet nginx; then
+    echo "> Nginx 재시작 성공"
+  else
+    echo "> Nginx 재시작 실패."
+  fi
+else
+  echo "> Nginx 정상 구동 중"
+fi
 
 echo "> 스위칭"
 sleep 10
 /home/ubuntu/app/nonstop/switch.sh
-
-echo "======= DIAG START ======="
-echo "[IP] $(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || echo NONE)"
-echo "[INST] $(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null || echo NONE)"
-echo "[SG] $(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/security-groups 2>/dev/null || echo NONE)"
-echo "[MAC] $(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/mac 2>/dev/null || echo NONE)"
-MAC=$(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/mac 2>/dev/null)
-if [ -n "$MAC" ]; then
-  echo "[VPC] $(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-id 2>/dev/null || echo NONE)"
-  echo "[SUBNET] $(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/subnet-id 2>/dev/null || echo NONE)"
-  echo "[SG-IDS] $(curl -s --connect-timeout 3 http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/security-group-ids 2>/dev/null || echo NONE)"
-fi
-echo "[NGINX] $(sudo systemctl is-active nginx 2>&1)"
-echo "[PORTS] $(sudo ss -tlnp 2>/dev/null | grep -E ':(80|8081|8082) ' || echo NONE)"
-echo "[JAVA] $(pgrep -a java 2>/dev/null | head -2 || echo NONE)"
-echo "[UFW] $(sudo ufw status 2>/dev/null | head -1)"
-echo "[IPT] $(sudo iptables -S 2>/dev/null | head -5)"
-echo "[LOCAL80] $(curl -s -o /dev/null -w '%{http_code}' http://localhost/actuator/health 2>/dev/null)"
-echo "[LOCAL8081] $(curl -s -o /dev/null -w '%{http_code}' http://localhost:8081/actuator/health 2>/dev/null)"
-echo "[LOCAL8082] $(curl -s -o /dev/null -w '%{http_code}' http://localhost:8082/actuator/health 2>/dev/null)"
-echo "[PROFILE] $(curl -s http://localhost/profile 2>/dev/null)"
-echo "[MEM] $(free -m 2>/dev/null | grep Mem | awk '{print $2"M total, "$3"M used, "$4"M free"}')"
-echo "======= DIAG END ======="
-exit 1


### PR DESCRIPTION
## Summary
- deploy.sh 진단 모드 제거, 정상 배포 스크립트로 복구
- Nginx 자동 재시작 로직 유지 (배포 안정성)
- 진단용 임시 워크플로우 정리

## 원인 확인
- 서버 다운의 실제 원인: EC2 Public IP 변경 (3.35.195.11 → 43.201.179.83)
- EC2 stop/start 시 Elastic IP가 아닌 자동 할당 IP가 변경됨
- 서버 자체는 정상 동작 중 (Health UP, API 응답 정상)

## 권장 조치
- Elastic IP 할당하여 IP 고정 필요