### PR TITLE
chore: update prod CodeDeploy app and deployment group name

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -90,9 +90,9 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PROD_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PROD_SECRET_KEY }}
       run:
-        aws deploy create-deployment 
-        --application-name runnect-prod-codedeploy
-        --deployment-group-name runnect-prod-codedeploy-group
+        aws deploy create-deployment
+        --application-name runnect-prod-app
+        --deployment-group-name runnect-prod-deploy-group
         --file-exists-behavior OVERWRITE 
         --s3-location bucket=runnect-prod-bucket,bundleType=zip,key=runnect_prod_server.zip
         --region ap-northeast-2

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle # 실제 application build
-        run: ./gradlew build
+      - name: Build with Gradle
+        run: ./gradlew build -x test


### PR DESCRIPTION
## 작업 배경
AWS 프리티어 계정 이전 작업으로 새 계정에 CodeDeploy 앱을 재생성하면서 앱 이름과 배포 그룹 이름이 변경됨

## 변경 사항
- `--application-name`: `runnect-prod-codedeploy` → `runnect-prod-app`
- `--deployment-group-name`: `runnect-prod-codedeploy-group` → `runnect-prod-deploy-group`

## 영향 범위
- `prod-cd.yml` 워크플로우만 수정
- main 브랜치 push 시 새 계정 CodeDeploy로 배포됨

## Test Plan
- [ ] main 브랜치에 머지 후 GitHub Actions CD 파이프라인 정상 동작 확인