### PR TITLE
모니터링 인프라 구축: ELK + Prometheus/Grafana + Slack 알림

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# 로컬 모니터링 스택 실행 전, 이 파일을 .env로 복사하고 실제 값을 채우세요.
+# .env는 .gitignore에 포함되어 있어 커밋되지 않습니다.
+
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXXXXXXX/XXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*.java @funnysunny08 @RinRinPARK @YuSuhwa-ve

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -33,7 +33,7 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        mkdir ./src/main/resources
+        mkdir -p ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        mkdir ./src/main/resources
+        mkdir -p ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -34,7 +34,7 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        mkdir ./src/main/resources
+        mkdir -p ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: make application.properties 파일 생성
         run: |
           ## create application.yml
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           
           # application.yml 파일 생성

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ application.yaml
 .DS_Store
 logs/
 test_write.tmp
+.env
+grafana/provisioning/alerting/contact-points.yml

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ application.yaml
 
 ### DS_Store
 .DS_Store
+logs/
+test_write.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,3 @@ application.yaml
 logs/
 test_write.tmp
 .env
-grafana/provisioning/alerting/contact-points.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# --- Build stage ---
+FROM gradle:8.2.1-jdk11 AS build
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY gradlew ./
+
+COPY src ./src
+
+# 로컬/모니터링 검증용 application.yml은 build context 루트에 두고 복사한다.
+# (CI/CD에서는 GitHub Secret으로 별도 생성 — 이 Dockerfile은 로컬 검증 전용)
+COPY application.yml ./application.yml
+
+RUN ./gradlew bootJar -x test --no-daemon
+
+# --- Run stage ---
+FROM eclipse-temurin:11-jre
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+COPY --from=build /app/application.yml application.yml
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar", "--spring.config.location=file:./application.yml"]

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	// Health Check
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// Monitoring - Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus:1.9.14'
+
 	// JPA & Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.27'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     volumes:
       - ./logstash.conf:/usr/share/logstash/pipeline/logstash.conf
       - ./logs:/usr/share/logstash/logs
+      - logstash_data:/usr/share/logstash/data
     ports:
       - "5044:5044"
     networks:
@@ -94,11 +95,6 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        sed "s|__SLACK_WEBHOOK_URL__|$${SLACK_WEBHOOK_URL}|g" /etc/grafana/provisioning/alerting/contact-points.yml.tpl > /etc/grafana/provisioning/alerting/contact-points.yml
-        exec /run.sh
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning
       - grafana_data:/var/lib/grafana
@@ -116,3 +112,4 @@ networks:
 volumes:
   postgres_data:
   grafana_data:
+  logstash_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,12 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        sed "s|__SLACK_WEBHOOK_URL__|$${SLACK_WEBHOOK_URL}|g" /etc/grafana/provisioning/alerting/contact-points.yml.tpl > /etc/grafana/provisioning/alerting/contact-points.yml
+        exec /run.sh
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning
       - grafana_data:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,112 @@
+version: "3.8"
+
+services:
+  runnect-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: runnect-app
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - ./logs:/app/logs
+    networks:
+      - runnect-net
+
+  postgres:
+    image: postgres:15
+    container_name: runnect-postgres
+    environment:
+      POSTGRES_DB: runnect
+      POSTGRES_USER: runnect
+      POSTGRES_PASSWORD: runnect_local_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - runnect-net
+
+  redis:
+    image: redis:7
+    container_name: runnect-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - runnect-net
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: runnect-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    networks:
+      - runnect-net
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.13.4
+    container_name: runnect-logstash
+    depends_on:
+      - elasticsearch
+    volumes:
+      - ./logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+      - ./logs:/usr/share/logstash/logs
+    ports:
+      - "5044:5044"
+    networks:
+      - runnect-net
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.4
+    container_name: runnect-kibana
+    depends_on:
+      - elasticsearch
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    networks:
+      - runnect-net
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: runnect-prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - runnect-app
+    networks:
+      - runnect-net
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: runnect-grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - runnect-net
+
+networks:
+  runnect-net:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  grafana_data:

--- a/grafana/provisioning/alerting/contact-points.yml
+++ b/grafana/provisioning/alerting/contact-points.yml
@@ -2,10 +2,10 @@ apiVersion: 1
 
 contactPoints:
   - orgId: 1
-    name: discord-alert
+    name: slack-alert
     receivers:
-      - uid: discord-alert-receiver
-        type: discord
+      - uid: slack-alert-receiver
+        type: slack
         settings:
-          url: "REPLACE_WITH_YOUR_DISCORD_WEBHOOK_URL"
-          use_discord_username: true
+          url: $__env{SLACK_WEBHOOK_URL}
+          username: "Grafana"

--- a/grafana/provisioning/alerting/contact-points.yml
+++ b/grafana/provisioning/alerting/contact-points.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: discord-alert
+    receivers:
+      - uid: discord-alert-receiver
+        type: discord
+        settings:
+          url: "REPLACE_WITH_YOUR_DISCORD_WEBHOOK_URL"
+          use_discord_username: true

--- a/grafana/provisioning/alerting/contact-points.yml.tpl
+++ b/grafana/provisioning/alerting/contact-points.yml.tpl
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: slack-alert
+    receivers:
+      - uid: slack-alert-receiver
+        type: slack
+        settings:
+          url: "__SLACK_WEBHOOK_URL__"
+          username: "Grafana"

--- a/grafana/provisioning/alerting/notification-policies.yml
+++ b/grafana/provisioning/alerting/notification-policies.yml
@@ -2,7 +2,7 @@ apiVersion: 1
 
 policies:
   - orgId: 1
-    receiver: discord-alert
+    receiver: slack-alert
     group_by: ["alertname"]
     group_wait: 10s
     group_interval: 1m

--- a/grafana/provisioning/alerting/notification-policies.yml
+++ b/grafana/provisioning/alerting/notification-policies.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: discord-alert
+    group_by: ["alertname"]
+    group_wait: 10s
+    group_interval: 1m
+    repeat_interval: 10m

--- a/grafana/provisioning/alerting/rules.yml
+++ b/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,48 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: runnect-alerts
+    folder: Runnect Alerts
+    interval: 30s
+    rules:
+      - uid: runnect-server-down
+        title: "Runnect Server Down"
+        condition: C
+        for: 30s
+        noDataState: Alerting
+        execErrState: Alerting
+        data:
+          - refId: A
+            datasourceUid: prometheus-ds
+            relativeTimeRange:
+              from: 120
+              to: 0
+            model:
+              expr: 'up{job="runnect-server"}'
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: "-100"
+            relativeTimeRange:
+              from: 120
+              to: 0
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator:
+                    type: lt
+                    params: [1]
+                  operator:
+                    type: and
+                  query:
+                    params: ["A"]
+                  reducer:
+                    type: last
+                    params: []
+        annotations:
+          summary: "Runnect 서버가 응답하지 않고 있습니다 (up == 0)"
+        labels:
+          severity: critical

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "Runnect Dashboards"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: true

--- a/grafana/provisioning/dashboards/json/runnect-overview.json
+++ b/grafana/provisioning/dashboards/json/runnect-overview.json
@@ -1,0 +1,56 @@
+{
+  "title": "Runnect Server Overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "10s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "JVM Heap Used (bytes)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{area=\"heap\", application=\"runnect-server\"})",
+          "legendFormat": "heap used"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "CPU Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "process_cpu_usage{application=\"runnect-server\"}",
+          "legendFormat": "cpu usage"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP Requests per Second",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"runnect-server\"}[1m])) by (status)",
+          "legendFormat": "status {{status}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Server Up",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "up{job=\"runnect-server\"}",
+          "legendFormat": "up"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus-ds
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/logstash.conf
+++ b/logstash.conf
@@ -2,7 +2,11 @@ input {
   file {
     path => "/usr/share/logstash/logs/runnect-server.log"
     start_position => "beginning"
-    sincedb_path => "/dev/null"
+    codec => multiline {
+      pattern => "^%{TIMESTAMP_ISO8601}"
+      negate => true
+      what => "previous"
+    }
   }
 }
 
@@ -15,6 +19,7 @@ filter {
 
   date {
     match => ["log_timestamp", "yyyy-MM-dd HH:mm:ss.SSS"]
+    timezone => "Asia/Seoul"
     target => "@timestamp"
   }
 }
@@ -22,6 +27,6 @@ filter {
 output {
   elasticsearch {
     hosts => ["http://elasticsearch:9200"]
-    index => "runnect-logs-%{+YYYY.MM.dd}"
+    index => "runnect-logs-%{+yyyy.MM.dd}"
   }
 }

--- a/logstash.conf
+++ b/logstash.conf
@@ -1,0 +1,27 @@
+input {
+  file {
+    path => "/usr/share/logstash/logs/runnect-server.log"
+    start_position => "beginning"
+    sincedb_path => "/dev/null"
+  }
+}
+
+filter {
+  grok {
+    match => {
+      "message" => "%{TIMESTAMP_ISO8601:log_timestamp} \[%{DATA:traceId}\] %{LOGLEVEL:level}%{SPACE}\[%{DATA:thread}\] %{DATA:logger} - %{GREEDYDATA:log_message}"
+    }
+  }
+
+  date {
+    match => ["log_timestamp", "yyyy-MM-dd HH:mm:ss.SSS"]
+    target => "@timestamp"
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "runnect-logs-%{+YYYY.MM.dd}"
+  }
+}

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "runnect-server"
+    metrics_path: "/internal-monitor/prometheus"
+    static_configs:
+      - targets: ["runnect-app:8080"]

--- a/src/main/java/org/runnect/server/config/logging/MdcLoggingFilter.java
+++ b/src/main/java/org/runnect/server/config/logging/MdcLoggingFilter.java
@@ -1,5 +1,6 @@
 package org.runnect.server.config.logging;
 
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
@@ -8,6 +9,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -16,6 +18,7 @@ import java.util.UUID;
  * 로그 패턴에 %X{traceId}를 포함시키면(logback-spring.xml), 여러 요청이 뒤섞인 로그에서도
  * 같은 traceId로 특정 요청의 흐름만 추적할 수 있다.
  */
+@Slf4j
 @Component
 public class MdcLoggingFilter implements Filter {
 
@@ -28,6 +31,8 @@ public class MdcLoggingFilter implements Filter {
         String traceId = UUID.randomUUID().toString().substring(0, TRACE_ID_LENGTH);
         try {
             MDC.put(TRACE_ID_KEY, traceId);
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            log.info("{} {}", httpRequest.getMethod(), httpRequest.getRequestURI());
             chain.doFilter(request, response);
         } finally {
             MDC.remove(TRACE_ID_KEY);

--- a/src/main/java/org/runnect/server/config/logging/MdcLoggingFilter.java
+++ b/src/main/java/org/runnect/server/config/logging/MdcLoggingFilter.java
@@ -1,0 +1,36 @@
+package org.runnect.server.config.logging;
+
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * 요청마다 traceId를 발급해 MDC에 담아둔다.
+ * 로그 패턴에 %X{traceId}를 포함시키면(logback-spring.xml), 여러 요청이 뒤섞인 로그에서도
+ * 같은 traceId로 특정 요청의 흐름만 추적할 수 있다.
+ */
+@Component
+public class MdcLoggingFilter implements Filter {
+
+    private static final String TRACE_ID_KEY = "traceId";
+    private static final int TRACE_ID_LENGTH = 8;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String traceId = UUID.randomUUID().toString().substring(0, TRACE_ID_LENGTH);
+        try {
+            MDC.put(TRACE_ID_KEY, traceId);
+            chain.doFilter(request, response);
+        } finally {
+            MDC.remove(TRACE_ID_KEY);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_DIR" value="./logs"/>
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] %-5level [%thread] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/runnect-server.log</file>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/runnect-server.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## 작업 배경
- 백엔드 모니터링/관측 가능성(Observability) 학습 및 실무 적용 목적으로, 로그 중앙화·메트릭 모니터링·장애 알림 체계가 전무했던 상태를 개선

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `Dockerfile`, `docker-compose.yml` | Gradle 멀티스테이지 빌드로 앱 컨테이너화, postgres/redis 포함 로컬 스택 구성 |
| `config/logging/MdcLoggingFilter` | 요청마다 traceId(UUID) 발급 후 MDC 저장, access log 라인 추가 |
| `logback-spring.xml` | 콘솔+파일(날짜별 롤링, gzip 압축, 30일 보관) 이중 appender, traceId 포함 로그 패턴 |
| `docker-compose.yml` (ELK) | Elasticsearch/Logstash/Kibana 추가, `logstash.conf`로 로그 grok 파싱 후 날짜별 인덱스 색인 |
| `application.yml`(관리형, 외부) | Actuator base-path 변경, 노출 엔드포인트를 health/info/metrics/prometheus로 제한 |
| `build.gradle` | `micrometer-registry-prometheus` 추가 |
| `prometheus.yml`, `docker-compose.yml`(Prometheus/Grafana) | 5초 간격 메트릭 스크랩, Grafana 데이터소스/대시보드/Alert Rule을 코드로 provisioning |
| `grafana/provisioning/alerting/*` | 서버 다운 감지(`up==0`) Alert Rule, Slack Contact Point(웹훅은 커밋하지 않고 `.env`+런타임 sed 치환으로 주입) |

## 영향 범위
- 신규 인프라 구성 요소 추가이며 기존 API 로직/엔드포인트 동작에는 변경 없음
- Actuator 엔드포인트 경로 및 노출 범위가 변경되어, 기존에 `/actuator/*`를 직접 참조하는 외부 연동(있다면)은 확인 필요
- 로컬 `docker-compose up`으로 실행 시에만 영향, 실제 배포 파이프라인(CI/CD, EC2)은 이번 PR에서 변경하지 않음

### 검증 매트릭스
(테스트 코드 변경 없음 — 아래는 로컬 docker-compose 환경에서 수행한 수동 검증 내역)

| 검증 항목 | 결과 |
| --- | --- |
| Actuator 헬스체크 (`/internal-monitor/health`) | DB/Redis/디스크/ping 전부 UP 확인 |
| Prometheus 스크랩 | Target `runnect-server` → `up` 상태 확인 |
| ELK 파이프라인 | Logstash가 로그를 Elasticsearch에 정상 색인(1,000건 이상), Kibana Data View 생성 확인 |
| Grafana 대시보드/데이터소스 | Prometheus 연동 및 커스텀 대시보드 provisioning 확인 |
| traceId 실동작 | 자체 서명 테스트 JWT로 인증 요청 실행 → 로그에 요청별 고유 traceId 기록 확인 |
| Slack 알림 End-to-End | `docker stop`으로 장애 시뮬레이션 → Prometheus `up=0` 감지 → Grafana Alert `pending`→`firing` 전환 → Slack 채널 실제 수신 확인 |

## Test Plan
- [x] 로컬 `docker-compose up`으로 전체 스택(8개 컨테이너) 기동 확인
- [x] Actuator/Prometheus/Grafana/ELK 파이프라인 개별 동작 확인
- [x] 장애 시뮬레이션을 통한 Slack 알림 End-to-End 확인
- [ ] 실제 배포 환경(EC2) 반영 여부 및 방식 결정 (별도 논의 필요)