### PR TITLE
feat: OTel agent 감지 시 -javaagent 자동 적용

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,7 +16,20 @@ else
 fi
 
 echo "> 애플리케이션 시작"
-nohup java -jar \
+OTEL_AGENT_JAR=$APP_DIR/grafana-opentelemetry-java.jar
+OTEL_ENV_FILE=$APP_DIR/otel.env
+JAVA_AGENT_OPTS=""
+if [ -f "$OTEL_AGENT_JAR" ] && [ -f "$OTEL_ENV_FILE" ]; then
+  echo "> Grafana OTel agent 감지, 모니터링 활성화"
+  set -a
+  source "$OTEL_ENV_FILE"
+  set +a
+  JAVA_AGENT_OPTS="-javaagent:$OTEL_AGENT_JAR"
+else
+  echo "> Grafana OTel agent 미설정, 모니터링 없이 실행"
+fi
+
+nohup java $JAVA_AGENT_OPTS -jar \
   -Duser.timezone=Asia/Seoul \
   $JAR_PATH \
   >> /home/ec2-user/app/nohup.out 2>&1 &


### PR DESCRIPTION
## 작업 배경
- Grafana Cloud(OpenTelemetry) 기반 모니터링을 dev/staging 서버에 도입하기 위해, 배포 스크립트가 OTel Java agent를 자동으로 붙이도록 수정

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `scripts/deploy.sh` | `/home/ec2-user/app/`에 `grafana-opentelemetry-java.jar`와 `otel.env`가 존재하면 자동 감지해서 `-javaagent` 옵션과 env var를 적용, 없으면 기존과 동일하게 부팅 |

## 영향 범위
- CI/CD 워크플로우(`dev-cd.yml` 등)는 변경 없음 — 배포 스크립트 로직만 조건부 분기 추가
- OTel agent 파일이 서버에 없는 경우 동작에 영향 없음 (하위 호환)
- dev/staging(`runnect-staging`, t3.micro) 서버에 agent jar + otel.env 파일을 이미 수동 배치 완료 (git에는 포함되지 않는 민감/대용량 파일이라 서버에 직접 배치)

## Test Plan
- [x] `bash -n scripts/deploy.sh` 문법 검증
- [x] SSH로 EC2 접속해 agent jar(24MB, 유효한 zip) + otel.env(권한 600) 배치 확인
- [ ] 이 PR 머지 후 CD 파이프라인으로 재배포되어 실제로 Grafana Cloud에 메트릭이 수집되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Grafana OpenTelemetry instrumentation during application startup when the required configuration and agent files are available.
  * Applications continue to start normally when instrumentation files are not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->