### PR TITLE
fix: 배포 스크립트 작업 디렉터리 미설정으로 인한 부팅 실패 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,7 @@
 set -e
 
 APP_DIR=/home/ec2-user/app
+cd "$APP_DIR"
 JAR_PATH=$(ls $APP_DIR/*.jar | grep -v plain | head -1)
 echo "> JAR 파일: $JAR_PATH"
 


### PR DESCRIPTION
## 작업 배경
- staging 서버(`runnect-staging`)가 PR #193 머지 시점(10:38)부터 계속 다운 상태였음. CodeDeploy 로그로 확인한 실제 원인 수정.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `scripts/deploy.sh` | 스크립트 시작 시 `cd "$APP_DIR"` 추가 |

## 영향 범위
- **근본 원인**: CodeDeploy가 `deploy.sh`를 실행할 때 작업 디렉터리가 `/`(루트)라서, `logback-spring.xml`의 상대경로(`./logs`)가 `/logs`로 해석되어 `ec2-user` 권한으로 생성 불가 → Logback 초기화 실패 → 앱 부팅 자체가 실패
- CodeDeploy 배포 로그(`codedeploy-agent-deployments.log`) 확인 결과 PR #193(10:38), PR #194(11:18) 배포 모두 헬스체크 10회 실패로 "배포 실패" 기록되어 있었음. GitHub Actions는 `aws deploy create-deployment` 호출 후 결과를 기다리지 않는 구조라 워크플로우 자체는 "성공"으로 표시되어 발견이 늦어짐
- `cd "$APP_DIR"` 추가로 상대경로가 앱 디렉터리 기준으로 올바르게 해석되어 로그 파일 생성 가능

## Test Plan
- [x] `bash -n scripts/deploy.sh` 문법 검증
- [ ] 머지 후 재배포되어 헬스체크 성공하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)