### PR TITLE
fix: 배포 헬스체크를 로그 기반 완료 신호 감지 방식으로 변경

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,27 +30,50 @@ else
   echo "> Grafana OTel agent 미설정, 모니터링 없이 실행"
 fi
 
+LOG_FILE=/home/ec2-user/app/nohup.out
+START_LINE=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+
 nohup java $JAVA_AGENT_OPTS -jar \
   -Duser.timezone=Asia/Seoul \
   $JAR_PATH \
-  >> /home/ec2-user/app/nohup.out 2>&1 &
+  >> "$LOG_FILE" 2>&1 &
+APP_PID=$!
+echo "> 프로세스 시작됨 (PID: $APP_PID)"
 
-echo "> 15초 후 헬스체크 시작"
-sleep 15
+echo "> 앱 준비 신호 대기 중 (최대 300초, 프로세스 생존 여부로 실패 판단)"
+MAX_WAIT=300
+ELAPSED=0
+READY=false
 
-for i in {1..10}; do
-  RESPONSE=$(curl -s http://localhost:8080/actuator/health || true)
-  if echo "$RESPONSE" | grep -q '"status":"UP"'; then
-    echo "> 헬스체크 성공"
-    break
-  fi
-  echo "> 헬스체크 실패($i/10): $RESPONSE"
-  if [ $i -eq 10 ]; then
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  if ! kill -0 $APP_PID 2>/dev/null; then
+    echo "> 프로세스가 예기치 않게 종료됨 (크래시)"
+    echo "> 최근 로그:"
+    tail -n 40 "$LOG_FILE"
     echo "> 배포 실패"
     exit 1
   fi
-  sleep 10
+
+  if tail -n +"$((START_LINE + 1))" "$LOG_FILE" | grep -q "Started ServerApplication"; then
+    echo "> 앱 준비 완료 신호 감지 (${ELAPSED}초 소요)"
+    READY=true
+    break
+  fi
+
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
 done
+
+if [ "$READY" != "true" ]; then
+  echo "> ${MAX_WAIT}초 내에 준비 신호 없음 — 안전장치 발동"
+  echo "> 최근 로그:"
+  tail -n 40 "$LOG_FILE"
+  echo "> 배포 실패"
+  exit 1
+fi
+
+RESPONSE=$(curl -s http://localhost:8080/actuator/health || true)
+echo "> 헬스체크 확인: $RESPONSE"
 
 echo "> Nginx 시작"
 sudo systemctl start nginx || true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -40,8 +40,8 @@ nohup java $JAVA_AGENT_OPTS -jar \
 APP_PID=$!
 echo "> 프로세스 시작됨 (PID: $APP_PID)"
 
-echo "> 앱 준비 신호 대기 중 (최대 300초, 프로세스 생존 여부로 실패 판단)"
-MAX_WAIT=300
+echo "> 앱 준비 신호 대기 중 (최대 240초, 프로세스 생존 여부로 실패 판단)"
+MAX_WAIT=240
 ELAPSED=0
 READY=false
 
@@ -72,7 +72,7 @@ if [ "$READY" != "true" ]; then
   exit 1
 fi
 
-RESPONSE=$(curl -s http://localhost:8080/actuator/health || true)
+RESPONSE=$(curl -s --max-time 10 http://localhost:8080/actuator/health || true)
 echo "> 헬스체크 확인: $RESPONSE"
 
 echo "> Nginx 시작"


### PR DESCRIPTION
## 작업 배경
- OTel agent 적용 후 부팅 시간이 3s→20~30s로 늘어나면서, 고정 타임아웃(15s+10x10s) 기반 헬스체크가 정상 배포도 "실패"로 오판하는 구조적 문제 발견

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `scripts/deploy.sh` | 고정 폴링 방식 제거, 프로세스 생존 여부(진짜 실패) + 로그 기반 완료 신호(`Started ServerApplication`) 감지 방식으로 교체 |

## 영향 범위
- 진짜 크래시(프로세스 종료)는 즉시 감지, 정상 부팅 중이면 시간이 얼마나 걸리든 계속 대기 (임의의 초/횟수 추측 제거)
- 5분 상한선은 여전히 존재하나, 이는 "정상 부팅 시간" 추측이 아니라 진짜 행(hang) 상황에 대한 안전장치로 성격이 다름
- CI/CD 워크플로우(dev-cd.yml 등)는 변경 없음

## Test Plan
- [x] `bash -n scripts/deploy.sh` 문법 검증
- [ ] 머지 후 실제 재배포하여 헬스체크가 정확히 판정하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment startup verification by waiting for the application to report that it has started.
  * Added detection and reporting for startup crashes and readiness timeouts.
  * Displays recent application logs when startup fails.
  * Performs a final health check after successful startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->