### PR TITLE
feat: Dockerfile에 Grafana OTel Java agent 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 COPY --from=build /app/application.yml application.yml
 
+# Grafana Cloud 모니터링용 OTel Java agent (없어도 앱 실행에는 영향 없음)
+RUN curl -sL -o grafana-opentelemetry-java.jar \
+    https://github.com/grafana/grafana-opentelemetry-java/releases/latest/download/grafana-opentelemetry-java.jar
+
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar", "--spring.config.location=file:./application.yml"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-javaagent:grafana-opentelemetry-java.jar", "-jar", "app.jar", "--spring.config.location=file:./application.yml"]


### PR DESCRIPTION
## 작업 배경
- Render 배포로 전환하면서 원래 EC2용으로 준비했던 Grafana Cloud 모니터링(JVM/APM 지표) 설정이 누락됨

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `Dockerfile` | 빌드 시점에 `grafana-opentelemetry-java.jar` 다운로드 + `ENTRYPOINT`에 `-javaagent` 추가 |

## 영향 범위
- 로컬 빌드/실행 시 검증: 이미지 빌드 성공, agent jar(24MB) 이미지 내 존재 확인
- Render는 자체 Docker Command 오버라이드를 쓰므로, 이 PR 머지와 별개로 Render 대시보드에서 Docker Command + 환경변수도 함께 갱신 예정
- EC2 배포 경로(`deploy.sh`)는 별도 로직(agent 파일 유무 조건부 감지)이라 이 변경과 무관, 계속 정상 동작

## Test Plan
- [x] `docker build` 로컬 성공 확인
- [x] 이미지 내 `grafana-opentelemetry-java.jar` 존재 확인
- [ ] Render 재배포 후 Grafana Cloud에 실제 메트릭 수집 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)