### PR TITLE
fix: 코스 생성 시 GPS 경로 전체를 로그에 남기던 코드 제거

### DIFF
--- a/src/main/java/org/runnect/server/common/module/convert/CoordinatePathConverter.java
+++ b/src/main/java/org/runnect/server/common/module/convert/CoordinatePathConverter.java
@@ -18,8 +18,7 @@ public class CoordinatePathConverter {
         try {
             return getLineString(path);
         } catch (Exception e) {
-            log.warn("course 요청 데이터 값 (path) -> " + path);
-            log.warn("course 요청 데이터 값의 타입 (path) -> " + path.getClass().getName());
+            log.warn("course 요청 데이터 변환 실패 (size={}, type={}): {}", path.size(), path.getClass().getName(), e.getMessage());
             throw new BadRequestException(ErrorStatus.VALIDATION_COURSE_PATH_EXCEPTION, ErrorStatus.VALIDATION_COURSE_PATH_EXCEPTION.getMessage());
         }
     }
@@ -43,16 +42,11 @@ public class CoordinatePathConverter {
     }
 
     private static LineString getLineString(List<CoordinateDto> coordinateDtos) {
-        StringBuilder sb = new StringBuilder();
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
         Coordinate[] coordinates = new Coordinate[coordinateDtos.size()];
         for (int i = 0; i < coordinateDtos.size(); i++) {
             coordinates[i] = new Coordinate(coordinateDtos.get(i).getLatitude(), coordinateDtos.get(i).getLongitude());
-            sb.append("(" + coordinateDtos.get(i).getLatitude() + ", " + coordinateDtos.get(i).getLongitude() + ")");
         }
-        LineString lineString = geometryFactory.createLineString(coordinates);
-        log.info("create course!");
-        log.info(sb.toString());
-        return lineString;
+        return geometryFactory.createLineString(coordinates);
     }
 }


### PR DESCRIPTION
## 작업 배경
- prod에 OTel 로그 수집을 붙이기 전 로깅 코드 PII 감사 중 발견
- `CoordinatePathConverter.getLineString()`이 매 코스 생성마다 전체 GPS 좌표를 INFO 레벨로 로깅하고 있었음 — 러닝 경로는 집/직장 위치 추정이 가능한 민감 데이터라, 외부 로그 수집(Grafana Cloud)으로 나가면 안 됨

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `CoordinatePathConverter.java` | 정상 경로에서 좌표 전체를 찍던 `log.info("create course!")` / `log.info(sb.toString())` 제거. 검증 실패 시 로그도 원본 좌표 대신 size/타입/에러 메시지만 남기도록 변경 |

## 영향 범위
- 로깅 내용만 변경, 코스 생성/변환 로직 자체는 동일 (좌표 → LineString 변환 결과 불변)
- 런타임 동작 영향 없음

## Test Plan
- [x] `./gradlew compileJava` 통과 확인
- [ ] dev 배포 후 코스 생성 API 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)