### PR TITLE
fix: deploy.sh를 2프로세스 롤링 재시작 방식으로 변경

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,77 +6,104 @@ cd "$APP_DIR"
 JAR_PATH=$(ls $APP_DIR/*.jar | grep -v plain | head -1)
 echo "> JAR 파일: $JAR_PATH"
 
-echo "> 실행 중인 애플리케이션 종료"
-CURRENT_PID=$(pgrep -f '\.jar' || true)
-if [ -n "$CURRENT_PID" ]; then
-  echo "> 종료: $CURRENT_PID"
-  kill -15 $CURRENT_PID
-  sleep 5
-else
-  echo "> 실행 중인 애플리케이션 없음"
-fi
-
-echo "> 애플리케이션 시작"
 OTEL_AGENT_JAR=$APP_DIR/grafana-opentelemetry-java.jar
 OTEL_ENV_FILE=$APP_DIR/otel.env
-JAVA_AGENT_OPTS=""
-if [ -f "$OTEL_AGENT_JAR" ] && [ -f "$OTEL_ENV_FILE" ]; then
-  echo "> Grafana OTel agent 감지, 모니터링 활성화"
-  set -a
-  source "$OTEL_ENV_FILE"
-  set +a
-  JAVA_AGENT_OPTS="-javaagent:$OTEL_AGENT_JAR"
-else
-  echo "> Grafana OTel agent 미설정, 모니터링 없이 실행"
-fi
 
-LOG_FILE=/home/ec2-user/app/nohup.out
-START_LINE=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+# 포트 하나씩 순서대로 종료→재기동한다 (롤링 재시작).
+# nginx가 두 포트를 upstream으로 물고 있어서, 한쪽이 재시작되는 동안에도
+# 다른 한쪽이 계속 트래픽을 받아 무중단으로 배포된다.
+deploy_process() {
+  local PORT=$1
+  local USE_OTEL=$2
+  local LOG_FILE=$APP_DIR/app-$PORT.log
 
-nohup java $JAVA_AGENT_OPTS -jar \
-  -Duser.timezone=Asia/Seoul \
-  $JAR_PATH \
-  >> "$LOG_FILE" 2>&1 &
-APP_PID=$!
-echo "> 프로세스 시작됨 (PID: $APP_PID)"
+  echo "=== [$PORT] 배포 시작 ==="
 
-echo "> 앱 준비 신호 대기 중 (최대 240초, 프로세스 생존 여부로 실패 판단)"
-MAX_WAIT=240
-ELAPSED=0
-READY=false
+  echo "> [$PORT] 실행 중인 프로세스 종료"
+  OLD_PID=$(pgrep -f "server.port=$PORT" || true)
+  if [ -n "$OLD_PID" ]; then
+    echo "> [$PORT] 종료: $OLD_PID"
+    kill -15 $OLD_PID
+    sleep 5
+  else
+    echo "> [$PORT] 실행 중인 프로세스 없음"
+  fi
 
-while [ $ELAPSED -lt $MAX_WAIT ]; do
-  if ! kill -0 $APP_PID 2>/dev/null; then
-    echo "> 프로세스가 예기치 않게 종료됨 (크래시)"
-    echo "> 최근 로그:"
+  JAVA_AGENT_OPTS=""
+  if [ "$USE_OTEL" = "true" ] && [ -f "$OTEL_AGENT_JAR" ] && [ -f "$OTEL_ENV_FILE" ]; then
+    echo "> [$PORT] Grafana OTel agent 활성화"
+    set -a
+    source "$OTEL_ENV_FILE"
+    set +a
+    JAVA_AGENT_OPTS="-javaagent:$OTEL_AGENT_JAR"
+  else
+    echo "> [$PORT] Grafana OTel agent 미적용"
+  fi
+
+  START_LINE=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+
+  nohup java $JAVA_AGENT_OPTS -jar \
+    -Duser.timezone=Asia/Seoul \
+    $JAR_PATH \
+    --server.port=$PORT \
+    >> "$LOG_FILE" 2>&1 &
+  APP_PID=$!
+  echo "> [$PORT] 프로세스 시작됨 (PID: $APP_PID)"
+
+  local MAX_WAIT=240
+  local ELAPSED=0
+  local READY=false
+
+  while [ $ELAPSED -lt $MAX_WAIT ]; do
+    if ! kill -0 $APP_PID 2>/dev/null; then
+      echo "> [$PORT] 프로세스가 예기치 않게 종료됨 (크래시)"
+      echo "> [$PORT] 최근 로그:"
+      tail -n 40 "$LOG_FILE"
+      return 1
+    fi
+
+    if tail -n +"$((START_LINE + 1))" "$LOG_FILE" | grep -q "Started ServerApplication"; then
+      echo "> [$PORT] 준비 완료 신호 감지 (${ELAPSED}초 소요)"
+      READY=true
+      break
+    fi
+
+    sleep 2
+    ELAPSED=$((ELAPSED + 2))
+  done
+
+  if [ "$READY" != "true" ]; then
+    echo "> [$PORT] ${MAX_WAIT}초 내에 준비 신호 없음 — 안전장치 발동"
+    echo "> [$PORT] 최근 로그:"
     tail -n 40 "$LOG_FILE"
-    echo "> 배포 실패"
-    exit 1
+    return 1
   fi
 
-  if tail -n +"$((START_LINE + 1))" "$LOG_FILE" | grep -q "Started ServerApplication"; then
-    echo "> 앱 준비 완료 신호 감지 (${ELAPSED}초 소요)"
-    READY=true
-    break
+  RESPONSE=$(curl -s --max-time 10 http://localhost:$PORT/actuator/health || true)
+  echo "> [$PORT] 헬스체크 확인: $RESPONSE"
+
+  if ! echo "$RESPONSE" | grep -q '"status":"UP"'; then
+    echo "> [$PORT] 헬스체크 실패"
+    return 1
   fi
 
-  sleep 2
-  ELAPSED=$((ELAPSED + 2))
-done
+  return 0
+}
 
-if [ "$READY" != "true" ]; then
-  echo "> ${MAX_WAIT}초 내에 준비 신호 없음 — 안전장치 발동"
-  echo "> 최근 로그:"
-  tail -n 40 "$LOG_FILE"
+if ! deploy_process 8080 true; then
+  echo "> 8080 배포 실패 — 8081은 계속 서비스 중이므로 전체 다운은 아니지만 배포는 실패 처리"
   echo "> 배포 실패"
   exit 1
 fi
 
-RESPONSE=$(curl -s --max-time 10 http://localhost:8080/actuator/health || true)
-echo "> 헬스체크 확인: $RESPONSE"
+if ! deploy_process 8081 false; then
+  echo "> 8081 배포 실패 — 8080은 정상 서비스 중이므로 전체 다운은 아니지만 배포는 실패 처리"
+  echo "> 배포 실패"
+  exit 1
+fi
 
 echo "> Nginx 시작"
 sudo systemctl start nginx || true
 sudo systemctl enable nginx || true
 
-echo "> 배포 완료"
+echo "> 배포 완료 (8080, 8081 모두 정상)"


### PR DESCRIPTION
## 배경
prod가 단일 인스턴스+단일 프로세스 구조에서, nginx + 2프로세스(8080/8081) 구조로 무중단 전환됨 (DNS 이중등록 기반 블루-그린 전환, 새 인스턴스 `runnect-prod`로 태그 교체 완료).

기존 `scripts/deploy.sh`는 실행 중인 jar 프로세스를 전부 찾아 한 번에 종료하고 새 프로세스 1개만 재기동하는 방식이라, 2프로세스 구조에 그대로 쓰면:
- 배포 시 두 프로세스가 동시에 죽어 nginx 뒤에 살아있는 백엔드가 0개가 되는 순간이 생김 (완전 다운)
- 새 프로세스가 1개만(기본 8080) 재기동되어 8081은 영영 안 살아남음

## 변경 내용
포트(8080, 8081)를 하나씩 순서대로 종료 → 재기동 → 헬스체크 확인하도록 변경 (롤링 재시작). 한쪽이 재시작되는 동안 nginx가 다른 한쪽으로 계속 트래픽을 보내므로 배포 중에도 무중단 유지.

- 8080: OTel agent 포함 (기존 관측성 유지)
- 8081: OTel agent 미포함 (메모리 절약, 512MB~1GB 인스턴스에서 발생했던 OOM 이슈 참고)
- 각 포트 재기동 후 로그의 준비 신호 + `/actuator/health` UP 여부까지 확인, 실패 시 해당 포트만 실패 처리(다른 포트는 서비스 유지)

## 테스트
- 새 인스턴스(t3.small)에서 동일한 2프로세스+nginx 구성으로 실 서비스 검증 완료 (kill -9 강제종료, kill -STOP hang, 전체다운 3가지 실패 케이스 재현 및 확인)
- CodeDeploy 배포 대상 인스턴스 태그(`Name=runnect-prod`)를 새 인스턴스로 교체 완료, CodeDeploy 에이전트 설치 및 실행 확인 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Deployments now use a rolling process across two application instances, helping maintain service availability during updates.
  * Each instance is verified to start successfully and pass health checks before deployment continues.
  * Failed deployments stop promptly and provide clearer diagnostic logs.

* **Operations**
  * Application logs are now separated by instance for easier troubleshooting.
  * Optional OpenTelemetry monitoring support is available during deployment.
  * Nginx is enabled after both instances are confirmed operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->