### PR TITLE
fix: Apple ID 토큰 서명 검증 누락 취약점 수정

### DIFF
--- a/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
+++ b/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
@@ -1,7 +1,14 @@
 package org.runnect.server.auth.service;
 
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import lombok.RequiredArgsConstructor;
 import okhttp3.OkHttpClient;
 import okhttp3.FormBody;
@@ -13,9 +20,8 @@ import org.runnect.server.common.constant.ErrorStatus;
 import org.runnect.server.common.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import com.nimbusds.jwt.SignedJWT;
 
-import java.text.ParseException;
+import java.net.URL;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -45,6 +51,8 @@ public class AppleSignInService {
 
     @Value("${apple.revoke-url}")
     private String APPLE_REVOKE_URL;
+    private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+
     private PrivateKey PRIVATE_KEY;
     @Value("${apple.p8key}")
     private void getPrivateKey(String P8KEY){
@@ -61,13 +69,12 @@ public class AppleSignInService {
 
     public SocialInfoResponseDto getSocialInfo(String idToken) {
 
-
         // 클라에서 준 인증토큰이 정말 애플에서 발급받은게 맞는지 확인
+        // (애플 공개키(JWKS)로 서명을 검증해야만 위조된 토큰을 걸러낼 수 있다 —
+        // 서명 검증 없이 파싱만 하면 누구나 클레임을 임의로 채운 토큰으로 로그인할 수 있음)
 
         try{
-            //1. idToken을 parse
-            SignedJWT jwt = SignedJWT.parse(idToken);
-            JWTClaimsSet claimsSet = jwt.getJWTClaimsSet();
+            JWTClaimsSet claimsSet = verifySignatureAndGetClaims(idToken);
 
             // 발급처, aud, 시간제한, 이메일 검증
 
@@ -90,11 +97,25 @@ public class AppleSignInService {
 
             return SocialInfoResponseDto.of(claimsSet.getStringClaim("email"), claimsSet.getSubject());
 
-        }catch (ParseException e){
+        }catch (UnauthorizedException e){
+            throw e;
+        }catch (Exception e){
+            // 서명 검증 실패(BadJOSEException), 파싱 실패(ParseException), JWKS 조회 실패(JOSEException) 등
+            // 위조/변조된 토큰 또는 애플 검증 자체가 불가능한 경우 전부 동일하게 처리
             throw new UnauthorizedException(ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION,
                     ErrorStatus.INVALID_APPLE_ID_TOKEN_EXCEPTION.getMessage());
         }
 
+    }
+
+    private JWTClaimsSet verifySignatureAndGetClaims(String idToken) throws Exception {
+        JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(new URL(APPLE_JWKS_URL));
+        ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+        JWSVerificationKeySelector<SecurityContext> keySelector =
+                new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keySource);
+        jwtProcessor.setJWSKeySelector(keySelector);
+        // 서명이 유효하지 않으면 여기서 BadJOSEException/JOSEException이 던져진다
+        return jwtProcessor.process(idToken, null);
     }
 
 //       id_token 형태 :


### PR DESCRIPTION
## 취약점
`AppleSignInService.getSocialInfo()`가 클라이언트가 보낸 Apple ID 토큰(`idToken`)을 `SignedJWT.parse()`로 **파싱만** 하고 암호학적 서명 검증을 한 번도 수행하지 않고 있었음.

검증 로직은 `iss`(발급처)/`aud`(대상)/`exp`(만료시간)/`email_verified` 클레임 **값**만 확인했는데, 서명 검증이 없으면 이 값들은 클라이언트가 3-segment 구조만 맞춰서 임의로 채울 수 있음. 즉 실제 Apple 로그인 없이도 `POST /api/auth`에 `provider=APPLE`과 함께 위조 토큰을 보내면 정식 유저 생성/조회 + accessToken·refreshToken 발급이 그대로 통과하는 상태였음.

## 수정
Apple의 공개키(JWKS, `https://appleid.apple.com/auth/keys`)로 RS256 서명을 검증하도록 변경. 이미 의존성에 있는 `nimbus-jose-jwt`의 `JWSVerificationKeySelector` + `RemoteJWKSet` + `DefaultJWTProcessor`를 사용해, 서명이 유효한 토큰에서만 클레임을 신뢰하도록 함 (새 의존성 추가 없음).

서명 검증 실패(`BadJOSEException`), JWKS 조회 실패(`JOSEException`), 파싱 실패(`ParseException`) 모두 기존과 동일하게 `INVALID_APPLE_ID_TOKEN_EXCEPTION`으로 처리.

## 발견 경위
부하테스트용 JWT 발급 방법을 조사하던 중 발견함 (Google/Kakao 로그인은 각각 `GoogleIdTokenVerifier`, 카카오 서버 API 호출로 정상 검증 중이며 이 이슈는 Apple 로그인 경로에만 해당).

## 테스트
`./gradlew compileJava` 성공 확인. (실제 Apple 기기로 로그인 재검증은 별도 필요)