### PR TITLE
perf: 공개 코스 조회 API에 Redis 캐싱 적용

### DIFF
--- a/src/main/java/org/runnect/server/config/redis/RedisConfig.java
+++ b/src/main/java/org/runnect/server/config/redis/RedisConfig.java
@@ -1,13 +1,21 @@
 package org.runnect.server.config.redis;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @EnableCaching
 @Configuration
@@ -28,6 +36,23 @@ public class RedisConfig {
     public ListOperations<String, String> listOperations(
         RedisTemplate<String, String> redisStringTemplate) {
         return redisStringTemplate.opsForList();
+    }
+
+    // 공개 코스 조회 API(전체 페이지 수/마라톤/추천 목록) 응답 캐싱용.
+    // TTL을 짧게(1분) 두어, 코스가 추가/삭제돼도 오래된 응답이 너무 길게 남지 않도록 함.
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(1))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfiguration)
+                .build();
     }
 }
 

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -38,6 +38,7 @@ import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
 import org.runnect.server.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -63,6 +64,8 @@ public class PublicCourseService {
                 .map(Long::parseLong).collect(Collectors.toList());
     }
 
+    // 전체 유저에게 동일한 값이라 캐시 키에 별도 파라미터가 필요 없음
+    @Cacheable(value = "publicCourseTotalPageCount")
     public GetPublicCourseTotalPageCountResponseDto getPublicCourseTotalPageCount() {
         Long totalPublicCourseCount = publicCourseRepository.countBy();
         if (totalPublicCourseCount % PAGE_SIZE != 0) {
@@ -71,6 +74,10 @@ public class PublicCourseService {
         return GetPublicCourseTotalPageCountResponseDto.of(totalPublicCourseCount / PAGE_SIZE);
     }
 
+    // 응답에 유저별 스크랩 여부(isScrap)가 섞여있어 userId를 캐시 키에 포함함
+    // (그만큼 유저별로 캐시가 나뉘어서, 여러 유저가 섞인 실트래픽에서는 히트율이
+    // 이번 부하테스트(단일 유저 반복 호출)만큼 극적이진 않을 수 있음)
+    @Cacheable(value = "marathonPublicCourse", key = "#userId")
     public GetMarathonPublicCourseResponseDto getMarathonPublicCourse(Long userId) {
         //1. 받은 userId가 유저가 존재하는지 확인
         RunnectUser user = userRepository.findById(userId)
@@ -150,6 +157,8 @@ public class PublicCourseService {
 
     }
 
+    // marathonPublicCourse와 동일한 이유로 userId를 캐시 키에 포함
+    @Cacheable(value = "recommendPublicCourse", key = "#userId + '_' + #pageNo + '_' + #sort")
     public RecommendPublicCourseResponseDto recommendPublicCourse(Long userId, Integer pageNo, String sort) {
         //1. 받은 userId가 유저가 존재하는지 확인
         RunnectUser user = userRepository.findById(userId)


### PR DESCRIPTION
## 배경
dev 환경에서 Artillery 부하테스트(초당 20건, KPI: p95 500ms 이하·에러율 0%) 결과 p95 9.3초·에러율 71%로 KPI 미달성. 응답시간이 구간마다 계속 치솟고 대기 요청이 눈덩이처럼 쌓이는 패턴을 확인 — 리전 간 DB 왕복(회당 약 60~90ms)이 동시 요청마다 반복되며 스레드/커넥션을 묶어두는 것이 원인으로 진단됨.

## 변경 내용
읽기 전용 3개 API(전체 페이지 수/마라톤/추천 목록)에 `@Cacheable` 적용, TTL 1분.
- `total-page-count`: 전체 유저 공통 응답이라 키 없이 캐싱
- `marathon`, `recommend`: 응답에 유저별 스크랩 여부(`isScrap`)가 섞여있어 `userId`(+페이지/정렬)를 캐시 키에 포함 — 실 트래픽에서는 유저가 분산되는 만큼 히트율이 이번 부하테스트(단일 유저 반복 호출)만큼 극적이진 않을 수 있음

`RedisConfig`에 명시적 `CacheManager` 빈 추가 — `GenericJackson2JsonRedisSerializer`로 DTO 직렬화, TTL 1분으로 캐시 무효화 리스크를 제한.

## 검증 (dev 환경)
동일 조건(초당 20건, 워밍업 10초+타겟 30초) 재테스트 결과:

| 지표 | Before | After |
|---|---|---|
| p95 응답시간 | 9,306ms | 4,488ms (약 52% 감소) |
| 성공(200) 비율 | 122/650 (18.8%) | 649/650 (99.8%) |
| 서버 다운(502) | 발생 | 미발생 |
| 저부하(5건/s) p95 | 2,254ms | 377ms (목표 500ms 달성) |

목표 부하(20건/s)에서 p95 500ms 자체는 아직 못 넘겼지만, 에러율은 사실상 해소되고 서버 크래시도 없어짐. 잔여 지연은 Render 0.1 vCPU 자체의 순수 처리 용량 한계로 판단(캐싱으로 해결 가능한 범위 밖).

## 알려진 한계
- 캐시 무효화: TTL 1분에 의존, 코스 추가/삭제 시 최대 1분간 오래된 응답 노출 가능
- 캐시 키에 userId가 섞인 두 엔드포인트는 실 서비스(다수 유저 분산 트래픽)에서는 이번 벤치마크만큼 히트율이 안 나올 수 있음