### PR TITLE
fix: deploy.sh가 OTel agent jar를 앱 jar로 잘못 선택하는 버그 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,7 @@ set -e
 
 APP_DIR=/home/ec2-user/app
 cd "$APP_DIR"
-JAR_PATH=$(ls $APP_DIR/*.jar | grep -v plain | head -1)
+JAR_PATH=$(ls $APP_DIR/*.jar | grep -v plain | grep -v opentelemetry | head -1)
 echo "> JAR 파일: $JAR_PATH"
 
 OTEL_AGENT_JAR=$APP_DIR/grafana-opentelemetry-java.jar


### PR DESCRIPTION
## 문제
Redis 캐싱 PR(#203) 배포 중 8080 프로세스가 크래시하며 배포 실패(`d-EO2NEUOXJ`).

`deploy.sh`의 JAR 선택 로직:
```bash
JAR_PATH=$(ls $APP_DIR/*.jar | grep -v plain | head -1)
```
`grafana-opentelemetry-java.jar`가 알파벳순으로 `server-0.0.1-SNAPSHOT.jar`보다 앞에 와서, **OTel agent jar 자체를 애플리케이션 jar로 잘못 선택**해 `java -javaagent:grafana-opentelemetry-java.jar -jar grafana-opentelemetry-java.jar`를 실행하려다 즉시 크래시.

처음 배포 스크립트를 만들 때는 이 디렉토리에 OTel agent jar가 없어서 안 걸렸는데, 이후 OTel 경로 문제를 고치면서 `/home/ec2-user/app/`에 복사해둔 게 이번에 문제가 됨.

## 수정
`grep -v opentelemetry` 추가해 OTel agent jar를 명시적으로 제외.

## 영향
8080 배포는 실패했지만, 롤링 재시작 설계(포트 하나씩만 처리, 실패 시 그 포트만 멈춤) 덕분에 8081이 계속 서비스해서 전체 다운은 없었음(외부에서는 계속 200 응답). 이번 PR 머지 후 재배포하면 8080도 정상화됨.