### PR TITLE
fix: 배포용 jar를 고정된 이름(app.jar)으로 복사해 선택 모호성 제거

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -60,7 +60,11 @@ jobs:
       
     # Jar 파일 복사
     - name: Copy Jar
-      run: cp ./build/libs/*.jar ./deploy
+      # 실행 가능한 jar 하나만 골라 고정된 이름(app.jar)으로 복사한다.
+      # deploy.sh가 ls/grep으로 여러 jar 중 하나를 "추측"하지 않고
+      # 이 고정 경로만 참조하도록 해서, 나중에 다른 jar 파일이 같은
+      # 디렉토리에 추가돼도(예: OTel agent jar) 절대 헷갈리지 않게 한다.
+      run: cp $(ls ./build/libs/*.jar | grep -v plain) ./deploy/app.jar
     
     # appspec.yml 파일 복사
     - name: Copy appspec.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,10 @@ set -e
 
 APP_DIR=/home/ec2-user/app
 cd "$APP_DIR"
-JAR_PATH=$(ls $APP_DIR/*.jar | grep -v plain | grep -v opentelemetry | head -1)
+# CI가 항상 app.jar라는 고정된 이름으로 복사해주므로, 여러 jar 중
+# 하나를 ls/grep으로 추측해서 고를 필요가 없다 (이 디렉토리에 다른
+# jar 파일이 나중에 추가돼도 절대 헷갈리지 않음).
+JAR_PATH=$APP_DIR/app.jar
 echo "> JAR 파일: $JAR_PATH"
 
 OTEL_AGENT_JAR=$APP_DIR/grafana-opentelemetry-java.jar


### PR DESCRIPTION
## 배경
직전 배포(#204)가 `deploy.sh`의 jar 선택 로직(`ls *.jar | grep -v plain | ...`) 문제로 8080 프로세스 크래시를 일으켰음. OTel agent jar가 알파벳순으로 앱 jar보다 앞에 와서 잘못 선택된 것이 원인 — `grep -v opentelemetry`로 급한 불은 껐지만, 이건 exclude 패턴 방식이라 **다른 새 파일이 추가되면 똑같은 문제가 재발할 수 있는 구조**임.

## 변경 내용
근본 원인(선택 모호성) 자체를 제거:
- CI `Copy Jar` 단계에서 실행 가능한 jar 하나만 골라 **고정된 이름 `app.jar`로 복사**
- `deploy.sh`는 이제 `$APP_DIR/app.jar` 고정 경로만 참조 — ls/grep으로 "추측"하는 과정 자체가 사라짐

이제 `/home/ec2-user/app/` 디렉토리에 어떤 파일이 나중에 추가되더라도 배포 스크립트가 헷갈릴 여지가 없음.

## 참고
기존에 깔려있던 `server-0.0.1-SNAPSHOT.jar`, `server-0.0.1-SNAPSHOT-plain.jar`는 이번 배포 후에도 정리 안 되고 남아있을 수 있음(CodeDeploy가 기존 파일을 자동으로 지우진 않음) — 동작에는 영향 없지만 원하면 별도로 정리 가능.