### PR TITLE
fix: 공개 코스 쓰기 작업 시 관련 캐시 즉시 무효화

### DIFF
--- a/src/main/java/org/runnect/server/course/service/CourseService.java
+++ b/src/main/java/org/runnect/server/course/service/CourseService.java
@@ -27,6 +27,7 @@ import org.runnect.server.user.entity.StampType;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
 import org.runnect.server.user.repository.UserRepository;
 import org.runnect.server.user.service.UserStampService;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -136,6 +137,9 @@ public class CourseService {
         return UpdateCourseResponseDto.of(course);
     }
 
+    // 조건부로 공개 코스가 같이 삭제될 수 있어(비공개 코스면 스킵), 매번 무효화해도
+    // 안전한 쪽(과다 무효화)을 택함 — 공개 코스 목록 캐시(전체페이지수/마라톤/추천) 대상
+    @CacheEvict(value = {"publicCourseTotalPageCount", "marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public DeleteCoursesResponseDto deleteCourses(List<Long> courseIdList, Long userId) {
         courseIdList.forEach(courseId -> {

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -38,6 +38,7 @@ import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
 import org.runnect.server.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -300,6 +301,9 @@ public class PublicCourseService {
 
     }
 
+    // 코스 목록에 영향을 주는 쓰기 작업이라, 작성자 본인 캐시만이 아니라
+    // 전체 유저가 보는 목록 캐시(전체페이지수/마라톤/추천)를 다 지워야 함
+    @CacheEvict(value = {"publicCourseTotalPageCount", "marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public CreatePublicCourseResponseDto createPublicCourse(
             final Long userId,
@@ -344,6 +348,7 @@ public class PublicCourseService {
 
     }
 
+    @CacheEvict(value = {"publicCourseTotalPageCount", "marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public DeletePublicCoursesResponseDto deletePublicCourses(
             Long userId,
@@ -389,6 +394,8 @@ public class PublicCourseService {
         return DeletePublicCoursesResponseDto.from(publicCourses.size());
     }
 
+    // 제목/설명만 바뀌고 코스 개수는 그대로라 전체페이지수 캐시는 지울 필요 없음
+    @CacheEvict(value = {"marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public UpdatePublicCourseResponseDto updatePublicCourse(Long userId, Long publicCourseId, String title, String description) {
         PublicCourse publicCourse = publicCourseRepository.findById(publicCourseId)


### PR DESCRIPTION
## Summary
- `PublicCourseService`의 코스 생성/수정/삭제, `CourseService`의 코스 삭제(공개 코스 연쇄 삭제 포함) 메서드에 `@CacheEvict` 추가
- 대상 캐시: `publicCourseTotalPageCount`, `marathonPublicCourse`, `recommendPublicCourse` (전체 유저 공용 목록이라 `allEntries=true`로 전체 무효화)

## Background
Redis 캐싱(#203) 적용 당시 TTL(1분)만 두고 `@CacheEvict`를 빠뜨려서, 코스가 추가/삭제/수정돼도 최대 1분 동안 오래된 목록이 그대로 노출되는 상태였음. 카프카 로드맵 검토 중(CDC 기반 캐시 무효화 유스케이스를 살펴보다가) 발견.

## Test plan
- [x] `JAVA_HOME`을 JDK 19로 지정해 로컬 컴파일 성공 확인 (로컬 기본 JDK 26은 Lombok 비호환이라 컴파일 자체가 안 됨 — 프로젝트와 무관한 환경 이슈)
- [ ] 머지 후 dev에서 코스 생성 → 즉시 목록에 반영되는지 수동 확인