### PR TITLE
feat: 코스발견 탭 상단 배너 조회 API 추가

### DIFF
--- a/src/main/java/org/runnect/server/banner/controller/BannerController.java
+++ b/src/main/java/org/runnect/server/banner/controller/BannerController.java
@@ -1,0 +1,26 @@
+package org.runnect.server.banner.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.banner.dto.response.GetBannerResponseDto;
+import org.runnect.server.banner.service.BannerService;
+import org.runnect.server.common.constant.SuccessStatus;
+import org.runnect.server.common.dto.ApiResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/banner")
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetBannerResponseDto> getBanners() {
+        return ApiResponseDto.success(SuccessStatus.GET_BANNER_SUCCESS, bannerService.getBanners());
+    }
+}

--- a/src/main/java/org/runnect/server/banner/dto/response/BannerResponse.java
+++ b/src/main/java/org/runnect/server/banner/dto/response/BannerResponse.java
@@ -1,0 +1,19 @@
+package org.runnect.server.banner.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BannerResponse {
+    private Integer index;
+    private String imageUrl;
+    private String linkUrl;
+
+    public static BannerResponse of(Integer index, String imageUrl, String linkUrl) {
+        return new BannerResponse(index, imageUrl, linkUrl);
+    }
+}

--- a/src/main/java/org/runnect/server/banner/dto/response/GetBannerResponseDto.java
+++ b/src/main/java/org/runnect/server/banner/dto/response/GetBannerResponseDto.java
@@ -1,0 +1,19 @@
+package org.runnect.server.banner.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetBannerResponseDto {
+    private List<BannerResponse> banners;
+
+    public static GetBannerResponseDto of(List<BannerResponse> banners) {
+        return new GetBannerResponseDto(banners);
+    }
+}

--- a/src/main/java/org/runnect/server/banner/entity/Banner.java
+++ b/src/main/java/org/runnect/server/banner/entity/Banner.java
@@ -1,0 +1,39 @@
+package org.runnect.server.banner.entity;
+
+import javax.persistence.*;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.runnect.server.common.entity.AuditingTimeEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Banner extends AuditingTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String linkUrl;
+
+    @Column(nullable = false)
+    private Integer sortOrder;
+
+    @Column(nullable = false)
+    private Boolean isActive;
+
+    @Builder
+    public Banner(String imageUrl, String linkUrl, Integer sortOrder) {
+        this.imageUrl = imageUrl;
+        this.linkUrl = linkUrl;
+        this.sortOrder = sortOrder;
+        this.isActive = true;
+    }
+}

--- a/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
+++ b/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
@@ -1,0 +1,11 @@
+package org.runnect.server.banner.repository;
+
+import java.util.List;
+
+import org.runnect.server.banner.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    List<Banner> findByIsActiveTrueOrderBySortOrderAsc();
+}

--- a/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
+++ b/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BannerRepository extends JpaRepository<Banner, Long> {
 
-    List<Banner> findByIsActiveTrueOrderBySortOrderAsc();
+    List<Banner> findByIsActiveTrueOrderBySortOrderAscIdAsc();
 }

--- a/src/main/java/org/runnect/server/banner/service/BannerService.java
+++ b/src/main/java/org/runnect/server/banner/service/BannerService.java
@@ -1,0 +1,30 @@
+package org.runnect.server.banner.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.banner.dto.response.BannerResponse;
+import org.runnect.server.banner.dto.response.GetBannerResponseDto;
+import org.runnect.server.banner.entity.Banner;
+import org.runnect.server.banner.repository.BannerRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    public GetBannerResponseDto getBanners() {
+        List<Banner> banners = bannerRepository.findByIsActiveTrueOrderBySortOrderAsc();
+
+        List<BannerResponse> bannerResponses = new ArrayList<>();
+        for (int index = 0; index < banners.size(); index++) {
+            Banner banner = banners.get(index);
+            bannerResponses.add(BannerResponse.of(index, banner.getImageUrl(), banner.getLinkUrl()));
+        }
+
+        return GetBannerResponseDto.of(bannerResponses);
+    }
+}

--- a/src/main/java/org/runnect/server/banner/service/BannerService.java
+++ b/src/main/java/org/runnect/server/banner/service/BannerService.java
@@ -17,7 +17,7 @@ public class BannerService {
     private final BannerRepository bannerRepository;
 
     public GetBannerResponseDto getBanners() {
-        List<Banner> banners = bannerRepository.findByIsActiveTrueOrderBySortOrderAsc();
+        List<Banner> banners = bannerRepository.findByIsActiveTrueOrderBySortOrderAscIdAsc();
 
         List<BannerResponse> bannerResponses = new ArrayList<>();
         for (int index = 0; index < banners.size(); index++) {

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -31,6 +31,7 @@ public enum SuccessStatus {
 
     GET_HEALTH_DATA_SUCCESS(HttpStatus.OK, "건강 데이터 조회 성공"),
     GET_HEALTH_SUMMARY_SUCCESS(HttpStatus.OK, "건강 통계 조회 성공"),
+    GET_BANNER_SUCCESS(HttpStatus.OK, "배너 조회 성공"),
 
 
     UPDATE_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 수정 성공"),


### PR DESCRIPTION
## 배경
코스발견 탭 상단 배너 이미지가 현재 파이어베이스에서 직접 내려오고 있음. 배너를 서버에서 관리할 수 있도록 조회 API를 우선 추가함. Android 연동은 후속 작업.

## 변경 사항
- `Banner` 엔티티 (`imageUrl`, `linkUrl`, `sortOrder`, `isActive`)
- `BannerRepository.findByIsActiveTrueOrderBySortOrderAscIdAsc()` — sortOrder 동률 시 id를 보조 정렬키로 사용해 결정론적으로 정렬
- `GET /api/banner` — 활성 배너를 sortOrder(동률 시 id) 순으로 반환. 응답 형태: `{ data: { banners: [{ index, imageUrl, linkUrl }] } }` (배너 없음 콜백 없이 `banners: []`로 응답)
- `SuccessStatus.GET_BANNER_SUCCESS` 추가

## 영향 범위
신규 도메인 추가로 기존 API/로직에는 영향 없음. 인증 불필요한 공개 엔드포인트.

## 검증
- `./gradlew compileJava` 성공
- 로컬 docker-compose(postgres/redis)로 서버 기동 후 `GET /api/banner` 호출 → `ddl-auto: update`로 `banner` 테이블 자동 생성 확인, `200 {"data":{"banners":[]}}` 정상 응답 확인 (배너 데이터가 아직 없어 빈 배열)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for retrieving active banners.
  * Banners are returned with their image links, destination links, and display order.
  * Results are sorted by banner order and include a successful response status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->