### PR TITLE
feat: 코스발견 탭 상단 배너 조회 API 추가 (prod)

### DIFF
--- a/src/main/java/org/runnect/server/banner/controller/BannerController.java
+++ b/src/main/java/org/runnect/server/banner/controller/BannerController.java
@@ -1,0 +1,26 @@
+package org.runnect.server.banner.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.banner.dto.response.GetBannerResponseDto;
+import org.runnect.server.banner.service.BannerService;
+import org.runnect.server.common.constant.SuccessStatus;
+import org.runnect.server.common.dto.ApiResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/banner")
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<GetBannerResponseDto> getBanners() {
+        return ApiResponseDto.success(SuccessStatus.GET_BANNER_SUCCESS, bannerService.getBanners());
+    }
+}

--- a/src/main/java/org/runnect/server/banner/dto/response/BannerResponse.java
+++ b/src/main/java/org/runnect/server/banner/dto/response/BannerResponse.java
@@ -1,0 +1,19 @@
+package org.runnect.server.banner.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BannerResponse {
+    private Integer index;
+    private String imageUrl;
+    private String linkUrl;
+
+    public static BannerResponse of(Integer index, String imageUrl, String linkUrl) {
+        return new BannerResponse(index, imageUrl, linkUrl);
+    }
+}

--- a/src/main/java/org/runnect/server/banner/dto/response/GetBannerResponseDto.java
+++ b/src/main/java/org/runnect/server/banner/dto/response/GetBannerResponseDto.java
@@ -1,0 +1,19 @@
+package org.runnect.server.banner.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetBannerResponseDto {
+    private List<BannerResponse> banners;
+
+    public static GetBannerResponseDto of(List<BannerResponse> banners) {
+        return new GetBannerResponseDto(banners);
+    }
+}

--- a/src/main/java/org/runnect/server/banner/entity/Banner.java
+++ b/src/main/java/org/runnect/server/banner/entity/Banner.java
@@ -1,0 +1,39 @@
+package org.runnect.server.banner.entity;
+
+import javax.persistence.*;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.runnect.server.common.entity.AuditingTimeEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Banner extends AuditingTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String linkUrl;
+
+    @Column(nullable = false)
+    private Integer sortOrder;
+
+    @Column(nullable = false)
+    private Boolean isActive;
+
+    @Builder
+    public Banner(String imageUrl, String linkUrl, Integer sortOrder) {
+        this.imageUrl = imageUrl;
+        this.linkUrl = linkUrl;
+        this.sortOrder = sortOrder;
+        this.isActive = true;
+    }
+}

--- a/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
+++ b/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
@@ -1,0 +1,11 @@
+package org.runnect.server.banner.repository;
+
+import java.util.List;
+
+import org.runnect.server.banner.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    List<Banner> findByIsActiveTrueOrderBySortOrderAsc();
+}

--- a/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
+++ b/src/main/java/org/runnect/server/banner/repository/BannerRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BannerRepository extends JpaRepository<Banner, Long> {
 
-    List<Banner> findByIsActiveTrueOrderBySortOrderAsc();
+    List<Banner> findByIsActiveTrueOrderBySortOrderAscIdAsc();
 }

--- a/src/main/java/org/runnect/server/banner/service/BannerService.java
+++ b/src/main/java/org/runnect/server/banner/service/BannerService.java
@@ -1,0 +1,30 @@
+package org.runnect.server.banner.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import org.runnect.server.banner.dto.response.BannerResponse;
+import org.runnect.server.banner.dto.response.GetBannerResponseDto;
+import org.runnect.server.banner.entity.Banner;
+import org.runnect.server.banner.repository.BannerRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    public GetBannerResponseDto getBanners() {
+        List<Banner> banners = bannerRepository.findByIsActiveTrueOrderBySortOrderAsc();
+
+        List<BannerResponse> bannerResponses = new ArrayList<>();
+        for (int index = 0; index < banners.size(); index++) {
+            Banner banner = banners.get(index);
+            bannerResponses.add(BannerResponse.of(index, banner.getImageUrl(), banner.getLinkUrl()));
+        }
+
+        return GetBannerResponseDto.of(bannerResponses);
+    }
+}

--- a/src/main/java/org/runnect/server/banner/service/BannerService.java
+++ b/src/main/java/org/runnect/server/banner/service/BannerService.java
@@ -17,7 +17,7 @@ public class BannerService {
     private final BannerRepository bannerRepository;
 
     public GetBannerResponseDto getBanners() {
-        List<Banner> banners = bannerRepository.findByIsActiveTrueOrderBySortOrderAsc();
+        List<Banner> banners = bannerRepository.findByIsActiveTrueOrderBySortOrderAscIdAsc();
 
         List<BannerResponse> bannerResponses = new ArrayList<>();
         for (int index = 0; index < banners.size(); index++) {

--- a/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
+++ b/src/main/java/org/runnect/server/common/constant/SuccessStatus.java
@@ -31,6 +31,7 @@ public enum SuccessStatus {
 
     GET_HEALTH_DATA_SUCCESS(HttpStatus.OK, "건강 데이터 조회 성공"),
     GET_HEALTH_SUMMARY_SUCCESS(HttpStatus.OK, "건강 통계 조회 성공"),
+    GET_BANNER_SUCCESS(HttpStatus.OK, "배너 조회 성공"),
 
 
     UPDATE_RECORD_SUCCESS(HttpStatus.OK, "활동 기록 수정 성공"),


### PR DESCRIPTION
## 배경
#209 (dev 반영 완료)의 배너 조회 API를 prod에도 반영. dev 브랜치 전체를 머지하면 배너와 무관한 대규모 인프라 변경(Grafana/Prometheus/ELK, deploy.sh 재작성 등, 아직 미검증)이 함께 나가므로, 배너 API 커밋만 별도로 cherry-pick해서 올림.

## 변경 사항
#209와 동일:
- `Banner` 엔티티, `BannerRepository`, `GetBannerResponseDto`/`BannerResponse`, `BannerService`, `BannerController`
- `GET /api/banner` — 활성 배너를 sortOrder(동률 시 id) 순으로 반환
- `SuccessStatus.GET_BANNER_SUCCESS` 추가

## 영향 범위
신규 도메인 추가로 기존 API/로직에는 영향 없음. 인증 불필요한 공개 엔드포인트. main 대상 배포이므로 병합 시 prod EC2에 실제 배포됨.

## 검증
- #209에서 로컬 docker-compose 기동 검증 + CodeRabbit 리뷰 2건 대응 완료
- cherry-pick 후 main 기준으로도 `./gradlew compileJava` 성공 확인