### PR TITLE
fix: prod CI가 임시 DB 컨테이너를 쓰도록 수정 (테스트 실행 포함)

### DIFF
--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -12,6 +12,32 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # 테스트(contextLoads 등)는 실제 prod DB/Redis가 아니라 CI 안에서 띄우는
+    # 임시 컨테이너를 바라보게 한다 (원격 prod 환경에 직접 의존하지 않도록).
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: runnect
+          POSTGRES_USER: runnect
+          POSTGRES_PASSWORD: runnect_local_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
@@ -42,4 +68,9 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build -x test
+        run: ./gradlew build
+        env:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/runnect
+          SPRING_DATASOURCE_USERNAME: runnect
+          SPRING_DATASOURCE_PASSWORD: runnect_local_password
+          SPRING_DATA_REDIS_HOST: localhost


### PR DESCRIPTION
## 작업 배경
- prod-ci.yml이 `-x test`로 테스트를 건너뛰고 있었고, 건너뛰지 않더라도 실제 원격 prod DB에 의존하는 구조였음. dev-ci에서 동일한 문제를 이미 겪고 고쳤던 것과 같은 패턴.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `.github/workflows/prod-ci.yml` | `-x test` 제거, CI 안에 임시 postgres/redis 컨테이너를 띄우고 그쪽을 바라보게 datasource/redis 접속 정보를 환경변수로 오버라이드 |

## 영향 범위
- CI 실행 방식만 변경, 애플리케이션 코드 변경 없음. main에 대한 PR을 낼 때마다 이제 실제로 테스트가 돌고, 원격 prod DB 상태에 의존하지 않는 격리된 환경에서 검증됨.
- 런타임(배포) 영향 없음 — CI 워크플로우 파일만 변경.

## Test Plan
- [x] dev-ci.yml에 동일 구조를 이미 적용해서 실제로 정상 동작하는 것 확인함 (PR #212)
- [ ] 이 PR 자체의 CI 실행 결과로 최종 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)