### PR TITLE
fix: refreshToken 검증 누락(Critical) + 카카오 500→401 수정 (prod)

### DIFF
--- a/src/main/java/org/runnect/server/auth/service/AuthService.java
+++ b/src/main/java/org/runnect/server/auth/service/AuthService.java
@@ -52,8 +52,12 @@ public class AuthService {
         try {
             // refreshToken으로 유저찾기
             final long userId =  Long.parseLong(tokenContents);
-            if(redisService.getValuesByKey(String.valueOf(userId)).isBlank()){
-                //탈취된 refreshToken인 경우
+            final String storedRefreshToken = redisService.getValuesByKey(String.valueOf(userId));
+            // Redis에 저장된 최신 refreshToken과 실제로 일치하는지까지 확인한다.
+            // (단순히 "뭔가 저장돼 있는지"만 보면, 재로그인 등으로 이미 무효화된
+            // 예전 refreshToken도 계속 accessToken 재발급에 쓰일 수 있었음)
+            if (storedRefreshToken == null || storedRefreshToken.isBlank() || !storedRefreshToken.equals(refreshToken)) {
+                //탈취되었거나 이미 무효화된 refreshToken인 경우
                 throw new InvalidRefreshTokenException(ErrorStatus.INVALID_REFRESH_TOKEN_EXCEPTION, ErrorStatus.INVALID_REFRESH_TOKEN_EXCEPTION.getMessage());
             }
             RunnectUser user = userRepository.findById(userId)
@@ -78,8 +82,6 @@ public class AuthService {
     @Transactional
     public AuthResponseDto signIn(SignInRequestDto signInRequestDto) {
         SocialType socialType = SocialType.valueOf(signInRequestDto.getProvider());
-
-        System.out.println("타입은? "+ socialType);
 
         SocialInfoResponseDto socialInfo = getSocialInfo(socialType, signInRequestDto.getToken());
 

--- a/src/main/java/org/runnect/server/auth/service/KakaoSignInService.java
+++ b/src/main/java/org/runnect/server/auth/service/KakaoSignInService.java
@@ -29,20 +29,24 @@ public class KakaoSignInService {
 
         HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
         RestTemplate rt = new RestTemplate();
-        ResponseEntity<String> response = rt.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.POST,
-                kakaoUserInfoRequest,
-                String.class
-        );
-
-        // responseBody 속 정보 꺼내기
-        String responseBody = response.getBody();
 
         String userId = null;
         String email = null;
 
         try {
+            // 카카오 API가 4xx/5xx를 반환하면(토큰 만료/무효 등, 흔히 발생) RestTemplate이
+            // 예외를 던진다. 이 try 블록 밖에 있으면 여기서 잡히지 않고 그대로 500으로
+            // 새어나가 버리므로(실제로는 401로 처리돼야 할 흔한 케이스인데도) 같이 묶는다.
+            ResponseEntity<String> response = rt.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.POST,
+                    kakaoUserInfoRequest,
+                    String.class
+            );
+
+            // responseBody 속 정보 꺼내기
+            String responseBody = response.getBody();
+
             JSONParser parser = new JSONParser();
             JSONObject obj = (JSONObject) parser.parse(responseBody);
             JSONObject kakao_account = (JSONObject) obj.get("kakao_account");

--- a/src/test/java/org/runnect/server/auth/service/AppleSignInServiceTest.java
+++ b/src/test/java/org/runnect/server/auth/service/AppleSignInServiceTest.java
@@ -1,0 +1,53 @@
+package org.runnect.server.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.runnect.server.common.exception.UnauthorizedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * AppleSignInService는 OkHttpClient/JWKS 서명 검증기를 메서드 내부에서 직접 생성해서
+ * (의존성 주입이 안 되어 있어서) 실제 애플 서버 통신 없이는 getSocialInfo()의
+ * 정상 경로(서명 검증 성공)를 순수 단위 테스트로 재현할 수 없다.
+ * 네트워크 없이 검증 가능한 두 가지 — P8 키 파싱, 잘못된 idToken 형식 — 만 다룬다.
+ */
+class AppleSignInServiceTest {
+
+    private String base64EncodedEcPrivateKey() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair keyPair = generator.generateKeyPair();
+        return Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
+    }
+
+    @Test
+    void 유효한_EC_비밀키면_정상적으로_파싱된다() throws Exception {
+        AppleSignInService service = new AppleSignInService();
+
+        ReflectionTestUtils.invokeMethod(service, "getPrivateKey", base64EncodedEcPrivateKey());
+
+        assertThat(ReflectionTestUtils.getField(service, "PRIVATE_KEY")).isNotNull();
+    }
+
+    @Test
+    void 잘못된_형식의_비밀키면_UnauthorizedException() {
+        AppleSignInService service = new AppleSignInService();
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "getPrivateKey", "not-a-valid-key"))
+            .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    void idToken이_JWT_형식이_아니면_UnauthorizedException() {
+        AppleSignInService service = new AppleSignInService();
+
+        assertThatThrownBy(() -> service.getSocialInfo("this-is-not-a-jwt"))
+            .isInstanceOf(UnauthorizedException.class);
+    }
+}

--- a/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java
@@ -1,0 +1,259 @@
+package org.runnect.server.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.runnect.server.auth.dto.request.SignInRequestDto;
+import org.runnect.server.auth.dto.response.AuthResponseDto;
+import org.runnect.server.auth.dto.response.GetNewTokenResponseDto;
+import org.runnect.server.auth.dto.response.SignInResponseDto;
+import org.runnect.server.auth.dto.response.SignUpResponseDto;
+import org.runnect.server.auth.dto.response.SocialInfoResponseDto;
+import org.runnect.server.common.constant.TokenStatus;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.redis.RedisService;
+import org.runnect.server.user.entity.RunnectUser;
+import org.runnect.server.user.entity.SocialType;
+import org.runnect.server.user.exception.authException.InvalidAccessTokenException;
+import org.runnect.server.user.exception.authException.InvalidRefreshTokenException;
+import org.runnect.server.user.exception.authException.TimeExpiredRefreshTokenException;
+import org.runnect.server.user.exception.userException.NotFoundUserException;
+import org.runnect.server.user.repository.UserRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private GoogleSignInService googleSignInService;
+    @Mock
+    private AppleSignInService appleSignInService;
+    @Mock
+    private KakaoSignInService kakaoSignInService;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private RedisService redisService;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(userRepository, googleSignInService, appleSignInService,
+            kakaoSignInService, jwtService, redisService);
+    }
+
+    private RunnectUser buildUser(Long id, String email, SocialType provider) {
+        RunnectUser user = RunnectUser.builder()
+            .nickname("러너" + id)
+            .socialId("social-" + id)
+            .email(email)
+            .provider(provider)
+            .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Nested
+    @DisplayName("getNewToken")
+    class GetNewToken {
+
+        @Test
+        @DisplayName("accessToken/refreshToken 모두 유효하고 redis에 저장된 값과 일치하면 새 accessToken을 발급한다")
+        void 정상_재발급() {
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.verifyToken("refresh")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.getJwtContents("refresh")).thenReturn("1");
+            when(redisService.getValuesByKey("1")).thenReturn("refresh");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(buildUser(1L, "a@runnect.io", SocialType.KAKAO)));
+            when(jwtService.issuedAccessToken(1L)).thenReturn("new-access");
+
+            GetNewTokenResponseDto response = authService.getNewToken("access", "refresh");
+
+            assertThat(response.getAccessToken()).isEqualTo("new-access");
+            assertThat(response.getRefreshToken()).isEqualTo("refresh");
+        }
+
+        @Test
+        @DisplayName("accessToken이 무효하면 InvalidAccessTokenException")
+        void accessToken_무효() {
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_INVALID);
+
+            assertThatThrownBy(() -> authService.getNewToken("access", "refresh"))
+                .isInstanceOf(InvalidAccessTokenException.class);
+        }
+
+        @Test
+        @DisplayName("refreshToken이 만료됐으면 TimeExpiredRefreshTokenException")
+        void refreshToken_만료() {
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.verifyToken("refresh")).thenReturn(TokenStatus.TOKEN_EXPIRED);
+
+            assertThatThrownBy(() -> authService.getNewToken("access", "refresh"))
+                .isInstanceOf(TimeExpiredRefreshTokenException.class);
+        }
+
+        @Test
+        @DisplayName("refreshToken이 무효하면 InvalidRefreshTokenException")
+        void refreshToken_무효() {
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.verifyToken("refresh")).thenReturn(TokenStatus.TOKEN_INVALID);
+
+            assertThatThrownBy(() -> authService.getNewToken("access", "refresh"))
+                .isInstanceOf(InvalidRefreshTokenException.class);
+        }
+
+        @Test
+        @DisplayName("[버그 수정 검증] redis에 저장된 값이 없으면 InvalidRefreshTokenException")
+        void redis에_저장된_값이_없음() {
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.verifyToken("refresh")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.getJwtContents("refresh")).thenReturn("1");
+            when(redisService.getValuesByKey("1")).thenReturn(null);
+
+            assertThatThrownBy(() -> authService.getNewToken("access", "refresh"))
+                .isInstanceOf(InvalidRefreshTokenException.class);
+
+            verify(jwtService, never()).issuedAccessToken(any());
+        }
+
+        @Test
+        @DisplayName("[버그 수정 검증] redis에 저장된 값이 요청한 refreshToken과 다르면(재로그인 등으로 무효화됨) InvalidRefreshTokenException")
+        void redis에_저장된_값과_다름() {
+            when(jwtService.verifyToken("old-refresh")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.getJwtContents("old-refresh")).thenReturn("1");
+            when(redisService.getValuesByKey("1")).thenReturn("new-refresh-issued-later");
+
+            assertThatThrownBy(() -> authService.getNewToken("access", "old-refresh"))
+                .isInstanceOf(InvalidRefreshTokenException.class);
+
+            verify(jwtService, never()).issuedAccessToken(any());
+        }
+
+        @Test
+        @DisplayName("refreshToken의 userId 클레임이 숫자가 아니면 NotFoundUserException")
+        void 클레임이_숫자가_아님() {
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.verifyToken("refresh")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.getJwtContents("refresh")).thenReturn("not-a-number");
+
+            assertThatThrownBy(() -> authService.getNewToken("access", "refresh"))
+                .isInstanceOf(NotFoundUserException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 NotFoundUserException")
+        void 존재하지_않는_유저() {
+            when(jwtService.verifyToken("access")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.verifyToken("refresh")).thenReturn(TokenStatus.TOKEN_VALID);
+            when(jwtService.getJwtContents("refresh")).thenReturn("1");
+            when(redisService.getValuesByKey("1")).thenReturn("refresh");
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.getNewToken("access", "refresh"))
+                .isInstanceOf(NotFoundUserException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("signIn")
+    class SignIn {
+
+        @Test
+        @DisplayName("신규 유저면 회원가입 처리하고 SignUpResponseDto를 반환한다")
+        void 신규_회원가입() {
+            when(kakaoSignInService.getSocialInfo("kakao-token")).thenReturn(
+                SocialInfoResponseDto.of("new@runnect.io", "social-1"));
+            when(userRepository.existsByEmailAndProvider("new@runnect.io", SocialType.KAKAO)).thenReturn(false);
+            when(userRepository.existsByNickname(org.mockito.ArgumentMatchers.any())).thenReturn(false);
+            RunnectUser savedUser = buildUser(1L, "new@runnect.io", SocialType.KAKAO);
+            when(userRepository.findByEmailAndProvider("new@runnect.io", SocialType.KAKAO))
+                .thenReturn(Optional.of(savedUser));
+            when(jwtService.issuedAccessToken(1L)).thenReturn("access");
+            when(jwtService.issuedRefreshToken(1L)).thenReturn("refresh");
+
+            AuthResponseDto response = authService.signIn(new SignInRequestDto("kakao-token", "KAKAO"));
+
+            assertThat(response).isInstanceOf(SignUpResponseDto.class);
+            verify(userRepository).save(any(RunnectUser.class));
+        }
+
+        @Test
+        @DisplayName("기존 유저면 로그인 처리하고 SignInResponseDto를 반환하며 새 유저를 저장하지 않는다")
+        void 기존_유저_로그인() {
+            when(googleSignInService.getSocialInfo("google-token")).thenReturn(
+                SocialInfoResponseDto.of("existing@runnect.io", "social-2"));
+            when(userRepository.existsByEmailAndProvider("existing@runnect.io", SocialType.GOOGLE)).thenReturn(true);
+            RunnectUser existingUser = buildUser(2L, "existing@runnect.io", SocialType.GOOGLE);
+            when(userRepository.findByEmailAndProvider("existing@runnect.io", SocialType.GOOGLE))
+                .thenReturn(Optional.of(existingUser));
+            when(jwtService.issuedAccessToken(2L)).thenReturn("access");
+            when(jwtService.issuedRefreshToken(2L)).thenReturn("refresh");
+
+            AuthResponseDto response = authService.signIn(new SignInRequestDto("google-token", "GOOGLE"));
+
+            assertThat(response).isInstanceOf(SignInResponseDto.class);
+            verify(userRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("APPLE provider면 appleSignInService로 소셜 정보를 조회한다")
+        void 애플_로그인() {
+            when(appleSignInService.getSocialInfo("apple-token")).thenReturn(
+                SocialInfoResponseDto.of("apple@runnect.io", "social-3"));
+            when(userRepository.existsByEmailAndProvider("apple@runnect.io", SocialType.APPLE)).thenReturn(true);
+            RunnectUser existingUser = buildUser(3L, "apple@runnect.io", SocialType.APPLE);
+            when(userRepository.findByEmailAndProvider("apple@runnect.io", SocialType.APPLE))
+                .thenReturn(Optional.of(existingUser));
+            when(jwtService.issuedAccessToken(3L)).thenReturn("access");
+            when(jwtService.issuedRefreshToken(3L)).thenReturn("refresh");
+
+            authService.signIn(new SignInRequestDto("apple-token", "APPLE"));
+
+            verify(appleSignInService).getSocialInfo("apple-token");
+            verify(googleSignInService, never()).getSocialInfo(any());
+            verify(kakaoSignInService, never()).getSocialInfo(any());
+        }
+
+        @Test
+        @DisplayName("생성된 임시 닉네임이 이미 존재하면 중복되지 않을 때까지 다시 생성한다")
+        void 닉네임_중복시_재생성() {
+            when(kakaoSignInService.getSocialInfo("kakao-token")).thenReturn(
+                SocialInfoResponseDto.of("new@runnect.io", "social-1"));
+            when(userRepository.existsByEmailAndProvider("new@runnect.io", SocialType.KAKAO)).thenReturn(false);
+            when(userRepository.existsByNickname(any())).thenReturn(true, true, false);
+            RunnectUser savedUser = buildUser(1L, "new@runnect.io", SocialType.KAKAO);
+            when(userRepository.findByEmailAndProvider("new@runnect.io", SocialType.KAKAO))
+                .thenReturn(Optional.of(savedUser));
+            when(jwtService.issuedAccessToken(1L)).thenReturn("access");
+            when(jwtService.issuedRefreshToken(1L)).thenReturn("refresh");
+
+            authService.signIn(new SignInRequestDto("kakao-token", "KAKAO"));
+
+            verify(userRepository, org.mockito.Mockito.times(3)).existsByNickname(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 provider 값이면 IllegalArgumentException")
+        void 잘못된_provider() {
+            assertThatThrownBy(() -> authService.signIn(new SignInRequestDto("token", "FACEBOOK")))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 배경
- dev PR #221에서 발견/수정한 Auth 관련 버그를 prod에 반영. Apple 서명 검증은 이미 main에 있어(PR #202) 이번엔 포함 안 함 — 이번 PR은 refreshToken 검증 버그와 카카오 예외처리 버그만.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `AuthService.getNewToken` | **[Critical]** Redis에 저장된 refreshToken과 요청값을 실제로 비교하도록 수정 |
| `AuthService.signIn` | 디버그용 `System.out.println` 제거 |
| `KakaoSignInService.getSocialInfo` | 카카오 API 호출을 try 블록 안으로 이동 (4xx가 500으로 새어나가던 문제 수정) |
| `AuthServiceTest`, `AppleSignInServiceTest` | 단위 테스트 16개 신규 |

## 영향 범위
- **보안 (Critical)**: `getNewToken`이 지금까지 Redis에 "뭔가 저장돼 있는지"만 확인하고 있어서, 재로그인 등으로 이미 무효화된 예전 refreshToken도 JWT 자체 만료 전까지는 계속 accessToken 재발급에 쓰일 수 있었음. 지금 이 순간 prod에도 동일하게 해당됨 — 이 PR로 실제 저장된 최신 토큰과 일치할 때만 재발급되도록 막힘.
- **가용성/모니터링**: 카카오 토큰 만료 같은 흔한 사용자 케이스가 500이 아니라 401로 정상 처리됨 — 불필요한 에러 알림(Slack/Sentry) 감소.

### 검증 매트릭스

| 영향 범위 | 테스트 코드 |
| --- | --- |
| refreshToken Critical 버그 수정 검증 | • [`redis에_저장된_값이_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L123)<br>• [`redis에_저장된_값과_다름`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L137) |
| refreshToken 재발급 - 정상/각종 무효 케이스 | • [`정상_재발급`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L78)<br>• [`accessToken_무효`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L94)<br>• [`refreshToken_만료`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L103)<br>• [`refreshToken_무효`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L113)<br>• [`클레임이_숫자가_아님`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L151)<br>• [`존재하지_않는_유저`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L162) |
| 소셜 로그인 - 신규가입/기존로그인/provider 분기 | • [`신규_회원가입`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L180)<br>• [`기존_유저_로그인`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L199)<br>• [`애플_로그인`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L217)<br>• [`닉네임_중복시_재생성`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L236)<br>• [`잘못된_provider`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AuthServiceTest.java#L254) |
| Apple P8 키 파싱 + idToken 형식 검증 (dev와 동일 파일, main엔 이미 서명검증 있어서 그대로 통과) | • [`유효한_EC_비밀키면_정상적으로_파싱된다`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AppleSignInServiceTest.java#L30)<br>• [`잘못된_형식의_비밀키면_UnauthorizedException`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AppleSignInServiceTest.java#L39)<br>• [`idToken이_JWT_형식이_아니면_UnauthorizedException`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/edb69f036dda4ef573fcd539a4159d42e56a979d/src/test/java/org/runnect/server/auth/service/AppleSignInServiceTest.java#L47) |

## Test Plan
- [x] 로컬에서 16개 전부 통과
- [x] main에는 docker-compose.yml이 없어 `docker run`으로 임시 DB/Redis 띄워서 `./gradlew build` 전체(ServerApplicationTests 포함) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)