### PR TITLE
test: BannerService/S3Service 단위 테스트 추가 + 이미지 업로드 크래시 버그 2건 수정

### DIFF
--- a/src/main/java/org/runnect/server/external/aws/S3Service.java
+++ b/src/main/java/org/runnect/server/external/aws/S3Service.java
@@ -70,8 +70,14 @@ public class S3Service {
 
     // 파일 유효성 검사
     private String getFileExtension(String fileName) {
-        if (fileName.length() == 0) {
+        if (fileName == null || fileName.isEmpty()) {
             throw new NotFoundException(ErrorStatus.NOT_FOUND_IMAGE_EXCEPTION, ErrorStatus.NOT_FOUND_IMAGE_EXCEPTION.getMessage());
+        }
+        int dotIndex = fileName.lastIndexOf(".");
+        // 파일명에 "."가 아예 없으면(lastIndexOf가 -1) substring(-1)에서 그대로
+        // StringIndexOutOfBoundsException(500)이 나던 부분 — 확장자 없는 파일로 명확히 처리한다.
+        if (dotIndex == -1) {
+            throw new BadRequestException(ErrorStatus.NOT_FOUND_IMAGE_EXCEPTION, ErrorStatus.NOT_FOUND_IMAGE_EXCEPTION.getMessage());
         }
         ArrayList<String> fileValidate = new ArrayList<>();
         fileValidate.add(".jpg");
@@ -80,11 +86,11 @@ public class S3Service {
         fileValidate.add(".JPG");
         fileValidate.add(".JPEG");
         fileValidate.add(".PNG");
-        String idxFileName = fileName.substring(fileName.lastIndexOf("."));
+        String idxFileName = fileName.substring(dotIndex);
         if (!fileValidate.contains(idxFileName)) {
             throw new BadRequestException(ErrorStatus.NOT_FOUND_IMAGE_EXCEPTION, ErrorStatus.NOT_FOUND_IMAGE_EXCEPTION.getMessage());
         }
-        return fileName.substring(fileName.lastIndexOf("."));
+        return idxFileName;
     }
 
     // 이미지 삭제

--- a/src/test/java/org/runnect/server/banner/service/BannerServiceTest.java
+++ b/src/test/java/org/runnect/server/banner/service/BannerServiceTest.java
@@ -1,0 +1,58 @@
+package org.runnect.server.banner.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.runnect.server.banner.dto.response.GetBannerResponseDto;
+import org.runnect.server.banner.entity.Banner;
+import org.runnect.server.banner.repository.BannerRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BannerServiceTest {
+
+    @Mock
+    private BannerRepository bannerRepository;
+
+    private BannerService bannerService;
+
+    private Banner buildBanner(Long id, String imageUrl, String linkUrl, int sortOrder) {
+        Banner banner = Banner.builder().imageUrl(imageUrl).linkUrl(linkUrl).sortOrder(sortOrder).build();
+        ReflectionTestUtils.setField(banner, "id", id);
+        return banner;
+    }
+
+    @Test
+    void 활성_배너를_정렬된_순서_그대로_0부터_인덱싱해서_반환한다() {
+        bannerService = new BannerService(bannerRepository);
+        Banner first = buildBanner(1L, "image1.png", "https://a.com", 0);
+        Banner second = buildBanner(2L, "image2.png", "https://b.com", 1);
+        when(bannerRepository.findByIsActiveTrueOrderBySortOrderAscIdAsc())
+            .thenReturn(Arrays.asList(first, second));
+
+        GetBannerResponseDto response = bannerService.getBanners();
+
+        assertThat(response.getBanners()).hasSize(2);
+        assertThat(response.getBanners().get(0).getIndex()).isEqualTo(0);
+        assertThat(response.getBanners().get(0).getImageUrl()).isEqualTo("image1.png");
+        assertThat(response.getBanners().get(1).getIndex()).isEqualTo(1);
+        assertThat(response.getBanners().get(1).getLinkUrl()).isEqualTo("https://b.com");
+    }
+
+    @Test
+    void 활성_배너가_없으면_빈_목록을_반환한다() {
+        bannerService = new BannerService(bannerRepository);
+        when(bannerRepository.findByIsActiveTrueOrderBySortOrderAscIdAsc())
+            .thenReturn(Collections.emptyList());
+
+        GetBannerResponseDto response = bannerService.getBanners();
+
+        assertThat(response.getBanners()).isEmpty();
+    }
+}

--- a/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java
+++ b/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java
@@ -1,0 +1,120 @@
+package org.runnect.server.external.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.runnect.server.common.exception.BadRequestException;
+import org.runnect.server.common.exception.NotFoundException;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    private S3Service s3Service;
+
+    @BeforeEach
+    void setUp() {
+        s3Service = new S3Service(amazonS3);
+        ReflectionTestUtils.setField(s3Service, "bucket", "runnect-test-bucket");
+    }
+
+    private void stubUploadedUrl() throws Exception {
+        when(amazonS3.getUrl(any(), any())).thenReturn(
+            new URL("https://runnect-test-bucket.s3.ap-northeast-2.amazonaws.com/course/image/test.jpg"));
+    }
+
+    @Nested
+    @DisplayName("uploadImage")
+    class UploadImage {
+
+        @Test
+        @DisplayName("정상적인 이미지 파일이면 업로드하고 URL을 반환한다")
+        void 정상_업로드() throws Exception {
+            stubUploadedUrl();
+            MultipartFile file = new MockMultipartFile("image", "photo.jpg", "image/jpeg", "content".getBytes());
+
+            String url = s3Service.uploadImage(file, "course");
+
+            assertThat(url).isEqualTo(
+                "https://runnect-test-bucket.s3.ap-northeast-2.amazonaws.com/course/image/test.jpg");
+        }
+
+        @Test
+        @DisplayName("대문자 확장자(.PNG)도 정상 업로드된다")
+        void 대문자_확장자() throws Exception {
+            stubUploadedUrl();
+            MultipartFile file = new MockMultipartFile("image", "photo.PNG", "image/png", "content".getBytes());
+
+            assertThat(s3Service.uploadImage(file, "course")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 확장자면 BadRequestException")
+        void 지원하지_않는_확장자() {
+            MultipartFile file = new MockMultipartFile("image", "photo.gif", "image/gif", "content".getBytes());
+
+            assertThatThrownBy(() -> s3Service.uploadImage(file, "course"))
+                .isInstanceOf(BadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("[버그 수정 검증] 파일명이 null이면 500(NPE) 대신 NotFoundException")
+        void 파일명이_null() {
+            MultipartFile file = new MockMultipartFile("image", null, "image/jpeg", "content".getBytes());
+
+            assertThatThrownBy(() -> s3Service.uploadImage(file, "course"))
+                .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("파일명이 빈 문자열이면 NotFoundException")
+        void 파일명이_빈문자열() {
+            MultipartFile file = new MockMultipartFile("image", "", "image/jpeg", "content".getBytes());
+
+            assertThatThrownBy(() -> s3Service.uploadImage(file, "course"))
+                .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("[버그 수정 검증] 확장자(.)가 없는 파일명이면 500(StringIndexOutOfBoundsException) 대신 BadRequestException")
+        void 확장자가_없는_파일명() {
+            MultipartFile file = new MockMultipartFile("image", "photo_without_extension", "image/jpeg",
+                "content".getBytes());
+
+            assertThatThrownBy(() -> s3Service.uploadImage(file, "course"))
+                .isInstanceOf(BadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("파일 스트림을 읽는 중 오류가 나면 NotFoundException")
+        void 스트림_읽기_실패() throws IOException {
+            MultipartFile file = mock(MultipartFile.class);
+            when(file.getOriginalFilename()).thenReturn("photo.jpg");
+            when(file.getInputStream()).thenThrow(new IOException("disk error"));
+
+            assertThatThrownBy(() -> s3Service.uploadImage(file, "course"))
+                .isInstanceOf(NotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 배경
- 테스트 커버리지 확장 마지막 단계. 남아있던 `BannerService`, `S3Service`에 단위 테스트 추가. `S3Service`는 `AmazonS3`가 생성자 주입돼있어 (Auth 계열과 달리) 순수 단위 테스트가 가능했음.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `S3Service.getFileExtension` | 파일명 null 체크 추가, 확장자(".") 없는 파일명 처리 추가 |
| `BannerServiceTest`, `S3ServiceTest` | 단위 테스트 9개 신규 |

## 발견해서 수정한 버그
`S3Service.uploadImage`가 업로드 파일명 검증 단계에서 두 가지 케이스에 500을 냈음:
1. 파일명이 `null`이면 `fileName.length()`에서 NPE
2. 파일명에 "."가 없으면 `lastIndexOf`가 -1을 반환하고 그대로 `substring(-1)`을 호출해 `StringIndexOutOfBoundsException`

둘 다 원래 "잘못된 이미지 파일입니다"(400/404)로 처리됐어야 할 케이스가 서버 에러로 새어나가고 있었음.

## ⚠️ 확인만 하고 고치지 않은 것
`S3Service.deleteFile()`의 `imageUrl.substring(49)`는 폴더명/버킷명 길이에 따라 항상 값이 달라지는데 49로 하드코딩돼있어 구조적으로 항상 맞을 수 없음. 다만 코드베이스 전체에서 이 메서드를 실제로 호출하는 곳이 없어(dead code) 지금 당장 영향은 없음. 실제 S3 URL 포맷 확인 없이 숫자만 바꾸는 건 오히려 위험해서 이번엔 손대지 않음 — **나중에 deleteFile을 실제로 연결해서 쓰기 전에 반드시 점검 필요**.

## 영향 범위
- 이미지 업로드 API에서 파일명이 없거나(null/빈값) 확장자가 없는 잘못된 요청을 보내는 극단적 케이스가 500 대신 400/404로 정상 처리됨. 정상적인 파일 업로드 흐름에는 영향 없음.
- 런타임 영향 없음.

### 검증 매트릭스

| 영향 범위 | 테스트 코드 |
| --- | --- |
| 배너 목록 조회 - 순서/인덱싱 | • [`활성_배너를_정렬된_순서_그대로_0부터_인덱싱해서_반환한다`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/banner/service/BannerServiceTest.java#L32)<br>• [`활성_배너가_없으면_빈_목록을_반환한다`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/banner/service/BannerServiceTest.java#L49) |
| 이미지 업로드 - 정상/확장자 검증 | • [`정상_업로드`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java#L53)<br>• [`대문자_확장자`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java#L65)<br>• [`지원하지_않는_확장자`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java#L74)<br>• [`스트림_읽기_실패`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java#L111) |
| 이미지 업로드 크래시 버그 수정 검증 | • [`파일명이_null`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java#L83)<br>• [`파일명이_빈문자열`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java#L92)<br>• [`확장자가_없는_파일명`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/3a2b8f21d017011add510ef1e73397babdc956f2/src/test/java/org/runnect/server/external/aws/S3ServiceTest.java#L101) |

## Test Plan
- [x] 로컬에서 신규 테스트 9개 전부 통과
- [x] 전체 테스트(188개) 함께 실행해도 간섭 없음 확인
- [x] 로컬 DB/Redis 띄우고 `./gradlew build` 전체(ServerApplicationTests 포함) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)