### PR TITLE
test: CourseController @WebMvcTest 파일럿 추가 + JPA Auditing 설정 분리

### DIFF
--- a/src/main/java/org/runnect/server/ServerApplication.java
+++ b/src/main/java/org/runnect/server/ServerApplication.java
@@ -2,9 +2,7 @@ package org.runnect.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class ServerApplication {
 	static {

--- a/src/main/java/org/runnect/server/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/org/runnect/server/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.runnect.server.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java
+++ b/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java
@@ -1,0 +1,230 @@
+package org.runnect.server.course.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.runnect.server.common.constant.TokenStatus;
+import org.runnect.server.common.exception.NotFoundException;
+import org.runnect.server.common.module.convert.CoordinateDto;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.slack.SlackApi;
+import org.runnect.server.course.dto.request.CourseCreateRequestDto;
+import org.runnect.server.course.dto.request.DeleteCoursesRequestDto;
+import org.runnect.server.course.dto.response.CourseCreateResponseDto;
+import org.runnect.server.course.dto.response.CourseGetByUserResponseDto;
+import org.runnect.server.course.dto.response.DeleteCoursesResponseDto;
+import org.runnect.server.course.dto.response.UpdateCourseResponseDto;
+import org.runnect.server.course.dto.response.UserResponse;
+import org.runnect.server.course.service.CourseService;
+import org.runnect.server.external.aws.S3Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 컨트롤러 레이어(라우팅, @Valid 검증, @UserId 인증 리졸버, 예외→HTTP 상태코드 매핑)를
+ * 서비스 레이어 단위 테스트와는 별개로 검증한다. CourseService/S3Service는 모킹하고
+ * 나머지(WebConfig, UserIdResolver, ControllerExceptionAdvice)는 실제 빈을 그대로 쓴다.
+ */
+@WebMvcTest(CourseController.class)
+class CourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CourseService courseService;
+    @MockBean
+    private S3Service s3Service;
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private SlackApi slackApi;
+
+    @BeforeEach
+    void setUpAuth() {
+        BDDMockito.lenient().when(jwtService.verifyToken("valid")).thenReturn(TokenStatus.TOKEN_VALID);
+        BDDMockito.lenient().when(jwtService.getJwtContents("valid")).thenReturn("1");
+    }
+
+    private <B extends org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder> B withAuth(
+        B builder) {
+        builder.header("accessToken", "valid").header("refreshToken", "valid");
+        return builder;
+    }
+
+    private CourseCreateRequestDto validCreateRequest() {
+        return new CourseCreateRequestDto(
+            Arrays.asList(new CoordinateDto(37.5665, 126.9780), new CoordinateDto(37.5651, 126.9895)),
+            "정왕역 코스", 5.2f, "정왕역", "경기 시흥시 정왕동");
+    }
+
+    @Nested
+    @DisplayName("POST /api/course")
+    class CreateCourse {
+
+        @Test
+        @DisplayName("정상 요청이면 201과 생성된 코스 정보를 반환한다")
+        void 정상_생성() throws Exception {
+            when(s3Service.uploadImage(any(), eq("course"))).thenReturn("https://image.example/course.png");
+            when(courseService.createCourse(eq(1L), any(), any()))
+                .thenReturn(CourseCreateResponseDto.of(100L, LocalDateTime.of(2026, 1, 1, 0, 0)));
+
+            MockMultipartFile data = new MockMultipartFile("data", "", "application/json",
+                objectMapper.writeValueAsBytes(validCreateRequest()));
+            MockMultipartFile image = new MockMultipartFile("image", "photo.jpg", "image/jpeg", "content".getBytes());
+
+            mockMvc.perform(withAuth(multipart("/api/course")).file(data).file(image))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(100));
+        }
+
+        @Test
+        @DisplayName("인증 헤더가 없으면 400과 함께 요청이 서비스까지 도달하지 않는다")
+        void 인증헤더_없음() throws Exception {
+            MockMultipartFile data = new MockMultipartFile("data", "", "application/json",
+                objectMapper.writeValueAsBytes(validCreateRequest()));
+            MockMultipartFile image = new MockMultipartFile("image", "photo.jpg", "image/jpeg", "content".getBytes());
+
+            mockMvc.perform(multipart("/api/course").file(data).file(image))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+
+            BDDMockito.verifyNoInteractions(courseService);
+        }
+
+        @Test
+        @DisplayName("title이 비어있으면 유효성 검증에서 400을 반환한다")
+        void 유효성검증_실패() throws Exception {
+            CourseCreateRequestDto invalid = new CourseCreateRequestDto(
+                Arrays.asList(new CoordinateDto(37.5665, 126.9780), new CoordinateDto(37.5651, 126.9895)),
+                "", 5.2f, "정왕역", "경기 시흥시 정왕동");
+            MockMultipartFile data = new MockMultipartFile("data", "", "application/json",
+                objectMapper.writeValueAsBytes(invalid));
+            MockMultipartFile image = new MockMultipartFile("image", "photo.jpg", "image/jpeg", "content".getBytes());
+
+            mockMvc.perform(withAuth(multipart("/api/course")).file(data).file(image))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(courseService);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/course/user")
+    class GetCourseByUser {
+
+        @Test
+        @DisplayName("정상 요청이면 200과 코스 목록을 반환한다")
+        void 정상_조회() throws Exception {
+            when(courseService.getCourseByUser(1L)).thenReturn(
+                CourseGetByUserResponseDto.of(UserResponse.of(1L), Collections.emptyList()));
+
+            mockMvc.perform(withAuth(get("/api/course/user")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.user.id").value(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/course/detail/{courseId}")
+    class GetCourseDetail {
+
+        @Test
+        @DisplayName("서비스에서 NotFoundException이 나면 400으로 매핑된다")
+        void 존재하지_않는_코스() throws Exception {
+            when(courseService.getCourseDetail(anyLong(), eq(1L)))
+                .thenThrow(new NotFoundException(
+                    org.runnect.server.common.constant.ErrorStatus.NOT_FOUND_COURSE_EXCEPTION,
+                    org.runnect.server.common.constant.ErrorStatus.NOT_FOUND_COURSE_EXCEPTION.getMessage()));
+
+            mockMvc.perform(withAuth(get("/api/course/detail/999")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/course/{courseId}")
+    class UpdateCourse {
+
+        @Test
+        @DisplayName("정상 요청이면 200과 수정된 제목을 반환한다")
+        void 정상_수정() throws Exception {
+            when(courseService.updateCourse(eq(1L), eq(10L), eq("새 제목")))
+                .thenReturn(UpdateCourseResponseDto.of(courseWithTitle(10L, "새 제목")));
+
+            mockMvc.perform(withAuth(patch("/api/course/10"))
+                    .contentType("application/json")
+                    .content("{\"title\":\"새 제목\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.course.title").value("새 제목"));
+        }
+
+        @Test
+        @DisplayName("title이 비어있으면 400을 반환한다")
+        void 빈_제목() throws Exception {
+            mockMvc.perform(withAuth(patch("/api/course/10"))
+                    .contentType("application/json")
+                    .content("{\"title\":\"\"}"))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(courseService);
+        }
+
+        private org.runnect.server.course.entity.Course courseWithTitle(Long id, String title) {
+            org.runnect.server.course.entity.Course course = org.runnect.server.course.entity.Course.builder()
+                .title(title)
+                .departureRegion("경기").departureCity("시흥시").departureTown("정왕동")
+                .distance(5.2f).image("image.png")
+                .path(org.runnect.server.common.module.convert.CoordinatePathConverter.coorConvertPath(
+                    Arrays.asList(new CoordinateDto(37.5665, 126.9780), new CoordinateDto(37.5651, 126.9895))))
+                .build();
+            org.springframework.test.util.ReflectionTestUtils.setField(course, "id", id);
+            return course;
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/course")
+    class DeleteCourses {
+
+        @Test
+        @DisplayName("정상 요청이면 200과 삭제 개수를 반환한다")
+        void 정상_삭제() throws Exception {
+            when(courseService.deleteCourses(Collections.singletonList(10L), 1L))
+                .thenReturn(DeleteCoursesResponseDto.from(1));
+
+            mockMvc.perform(withAuth(put("/api/course"))
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(
+                        new DeleteCoursesRequestDto(Collections.singletonList(10L)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.deletedCourseCount").value(1));
+        }
+    }
+}


### PR DESCRIPTION
## 작업 배경
- 서비스 레이어 단위 테스트 스윕에 이어, 컨트롤러 레이어(라우팅, @Valid 검증, @UserId 인증 리졸버, 예외→HTTP 상태코드 매핑)를 검증하는 @WebMvcTest 슬라이스 테스트를 파일럿으로 도입한다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `ServerApplication.java` | 루트 설정 클래스에 붙어있던 `@EnableJpaAuditing`을 제거 |
| `config/jpa/JpaAuditingConfig.java` (신규) | `@EnableJpaAuditing`을 별도 `@Configuration` 클래스로 분리 |
| `course/controller/CourseControllerTest.java` (신규) | CourseController 5개 엔드포인트에 대한 @WebMvcTest 파일럿 (8 테스트) |

## 영향 범위
- `@EnableJpaAuditing`이 루트 `@SpringBootApplication` 클래스에 있으면, `@WebMvcTest`가 엔티티를 전혀 스캔하지 않는 상태에서도 JPA Auditing 인프라(`jpaMappingContext`)를 억지로 초기화하려다 `JPA metamodel must not be empty!`로 컨텍스트 로딩 자체가 실패하는 문제가 있었음. 별도 `@Configuration` 클래스로 분리하면 슬라이스 테스트의 컴포넌트 스캔 필터에서 제외되어 문제가 해결됨.
- 런타임 동작(전체 컨텍스트 기준 JPA Auditing 활성화)은 동일 — `ServerApplicationTests.contextLoads()` 포함 전체 196개 테스트 로컬 DB/Redis 기동 후 통과 확인.
- 컨트롤러 레이어 자체 로직 변경 없음 (테스트 전용 변경).

### 검증 매트릭스

| 영향 범위 | 테스트 코드 |
| --- | --- |
| POST /api/course 정상 생성 (multipart) | • [`정상_생성`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L91) |
| POST /api/course 인증 헤더 없으면 400, 서비스 미호출 | • [`인증헤더_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L108) |
| POST /api/course title 빈값이면 400 | • [`유효성검증_실패`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L122) |
| GET /api/course/user 정상 조회 | • [`정상_조회`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L143) |
| GET /api/course/detail/{id} NotFoundException → 400 매핑 | • [`존재하지_않는_코스`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L159) |
| PATCH /api/course/{id} 정상 수정 | • [`정상_수정`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L177) |
| PATCH /api/course/{id} title 빈값이면 400 | • [`빈_제목`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L190) |
| PUT /api/course 정상 삭제 | • [`정상_삭제`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/dc2ce33a3a143279c5df762e4cf5e56e7e63cda4/src/test/java/org/runnect/server/course/controller/CourseControllerTest.java#L218) |

## Test Plan
- [x] `./gradlew test --tests "...CourseControllerTest"` 8/8 통과
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 196/196 통과 (ServerApplicationTests.contextLoads() 포함)
- [ ] 나머지 컨트롤러(Record/PublicCourse/User/Scrap/Health/Auth/Banner)로 @WebMvcTest 확대

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of data change tracking across application features.

* **Tests**
  * Added comprehensive coverage for course creation, retrieval, updates, and deletion.
  * Added validation for authentication, request errors, response formatting, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->