### PR TITLE
test: Health/Scrap/Banner/UserStamp/ServerProfile 컨트롤러 @WebMvcTest 추가

### DIFF
--- a/src/test/java/org/runnect/server/banner/controller/BannerControllerTest.java
+++ b/src/test/java/org/runnect/server/banner/controller/BannerControllerTest.java
@@ -1,0 +1,56 @@
+package org.runnect.server.banner.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.runnect.server.banner.dto.response.BannerResponse;
+import org.runnect.server.banner.dto.response.GetBannerResponseDto;
+import org.runnect.server.banner.service.BannerService;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.slack.SlackApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BannerController.class)
+class BannerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BannerService bannerService;
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private SlackApi slackApi;
+
+    @Test
+    @DisplayName("GET /api/banner - 정상 요청이면 200과 배너 목록을 반환한다")
+    void 정상_조회() throws Exception {
+        List<BannerResponse> banners = Collections.singletonList(BannerResponse.of(0, "image.png", "https://a.com"));
+        when(bannerService.getBanners()).thenReturn(GetBannerResponseDto.of(banners));
+
+        mockMvc.perform(get("/api/banner"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.banners[0].index").value(0))
+            .andExpect(jsonPath("$.data.banners[0].imageUrl").value("image.png"));
+    }
+
+    @Test
+    @DisplayName("GET /api/banner - 배너가 없으면 200과 빈 목록을 반환한다")
+    void 배너_없음() throws Exception {
+        when(bannerService.getBanners()).thenReturn(GetBannerResponseDto.of(Collections.emptyList()));
+
+        mockMvc.perform(get("/api/banner"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.banners").isEmpty());
+    }
+}

--- a/src/test/java/org/runnect/server/common/controller/ServerProfileControllerTest.java
+++ b/src/test/java/org/runnect/server/common/controller/ServerProfileControllerTest.java
@@ -1,0 +1,36 @@
+package org.runnect.server.common.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.slack.SlackApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ServerProfileController.class)
+@ActiveProfiles("test")
+class ServerProfileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private SlackApi slackApi;
+
+    @Test
+    @DisplayName("GET /profile - 활성 프로파일명을 그대로 반환한다")
+    void 활성_프로파일_반환() throws Exception {
+        mockMvc.perform(get("/profile"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("test"));
+    }
+}

--- a/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java
+++ b/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java
@@ -1,0 +1,187 @@
+package org.runnect.server.health.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.runnect.server.common.constant.ErrorStatus;
+import org.runnect.server.common.constant.TokenStatus;
+import org.runnect.server.common.exception.ConflictException;
+import org.runnect.server.common.exception.PermissionDeniedException;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.slack.SlackApi;
+import org.runnect.server.health.dto.request.HealthDataRequestDto;
+import org.runnect.server.health.dto.response.CreateHealthDataResponseDto;
+import org.runnect.server.health.dto.response.GetHealthDataResponseDto;
+import org.runnect.server.health.dto.response.GetHealthSummaryResponseDto;
+import org.runnect.server.health.service.HealthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@WebMvcTest(HealthController.class)
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private HealthService healthService;
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private SlackApi slackApi;
+
+    @BeforeEach
+    void setUpAuth() {
+        BDDMockito.lenient().when(jwtService.verifyToken("valid")).thenReturn(TokenStatus.TOKEN_VALID);
+        BDDMockito.lenient().when(jwtService.getJwtContents("valid")).thenReturn("1");
+    }
+
+    private <B extends MockHttpServletRequestBuilder> B withAuth(B builder) {
+        builder.header("accessToken", "valid").header("refreshToken", "valid");
+        return builder;
+    }
+
+    private HealthDataRequestDto validRequest() {
+        return new HealthDataRequestDto(150.0, 180.0, 100.0, 320.0, 60, 120, 90, 30, 10, 190.0, Collections.emptyList());
+    }
+
+    @Nested
+    @DisplayName("POST /api/record/{recordId}/health")
+    class CreateHealthData {
+
+        @Test
+        @DisplayName("정상 요청이면 201과 생성된 건강 데이터 id를 반환한다")
+        void 정상_생성() throws Exception {
+            when(healthService.createHealthData(eq(1L), eq(10L), any()))
+                .thenReturn(CreateHealthDataResponseDto.of(100L));
+
+            mockMvc.perform(withAuth(post("/api/record/10/health"))
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.healthDataId").value(100));
+        }
+
+        @Test
+        @DisplayName("필수값(avgHeartRate)이 없으면 400을 반환한다")
+        void 필수값_없음() throws Exception {
+            mockMvc.perform(withAuth(post("/api/record/10/health"))
+                    .contentType("application/json")
+                    .content("{\"calories\":320.0,\"zone1Seconds\":1,\"zone2Seconds\":1,\"zone3Seconds\":1,\"zone4Seconds\":1,\"zone5Seconds\":1}"))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(healthService);
+        }
+
+        @Test
+        @DisplayName("다른 유저의 레코드면 403을 반환한다")
+        void 소유권_없음() throws Exception {
+            when(healthService.createHealthData(eq(1L), eq(10L), any()))
+                .thenThrow(new PermissionDeniedException(
+                    ErrorStatus.PERMISSION_DENIED_HEALTH_DATA_EXCEPTION,
+                    ErrorStatus.PERMISSION_DENIED_HEALTH_DATA_EXCEPTION.getMessage()));
+
+            mockMvc.perform(withAuth(post("/api/record/10/health"))
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("이미 건강 데이터가 있으면 409를 반환한다")
+        void 이미_존재() throws Exception {
+            when(healthService.createHealthData(eq(1L), eq(10L), any()))
+                .thenThrow(new ConflictException(
+                    ErrorStatus.ALREADY_EXIST_HEALTH_DATA_EXCEPTION,
+                    ErrorStatus.ALREADY_EXIST_HEALTH_DATA_EXCEPTION.getMessage()));
+
+            mockMvc.perform(withAuth(post("/api/record/10/health"))
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/record/{recordId}/health")
+    class GetHealthData {
+
+        @Test
+        @DisplayName("정상 요청이면 200과 건강 데이터를 반환한다")
+        void 정상_조회() throws Exception {
+            GetHealthDataResponseDto.ZoneResponse zones =
+                GetHealthDataResponseDto.ZoneResponse.of(60, 120, 90, 30, 10);
+            GetHealthDataResponseDto response = GetHealthDataResponseDto.of(
+                GetHealthDataResponseDto.HealthDataDetailResponse.of(
+                    100L, 10L, 150.0, 180.0, 100.0, 320.0, zones, 190.0, Collections.emptyList()));
+            when(healthService.getHealthData(anyLong(), eq(10L))).thenReturn(response);
+
+            mockMvc.perform(withAuth(get("/api/record/10/health")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.healthData.id").value(100));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/health/summary")
+    class GetHealthSummary {
+
+        @Test
+        @DisplayName("정상 요청이면 200과 요약 데이터를 반환한다")
+        void 정상_조회() throws Exception {
+            GetHealthSummaryResponseDto response = GetHealthSummaryResponseDto.of(
+                GetHealthSummaryResponseDto.HealthSummaryResponse.of(
+                    10L, 5L, 150.0, 300.0, 1500.0,
+                    GetHealthDataResponseDto.ZoneResponse.of(60, 120, 90, 30, 10)));
+            when(healthService.getHealthSummary(1L, "2026-01-01", "2026-01-31")).thenReturn(response);
+
+            mockMvc.perform(withAuth(get("/api/health/summary")
+                    .param("startDate", "2026-01-01")
+                    .param("endDate", "2026-01-31")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.summary.totalRecords").value(10));
+        }
+
+        @Test
+        @DisplayName("필수 파라미터가 없으면 400을 반환한다")
+        void 파라미터_없음() throws Exception {
+            mockMvc.perform(withAuth(get("/api/health/summary").param("startDate", "2026-01-01")))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(healthService);
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/record/{recordId}/health")
+    class DeleteHealthData {
+
+        @Test
+        @DisplayName("정상 요청이면 200을 반환한다")
+        void 정상_삭제() throws Exception {
+            mockMvc.perform(withAuth(delete("/api/record/10/health")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+        }
+    }
+}

--- a/src/test/java/org/runnect/server/scrap/controller/ScrapControllerTest.java
+++ b/src/test/java/org/runnect/server/scrap/controller/ScrapControllerTest.java
@@ -1,0 +1,122 @@
+package org.runnect.server.scrap.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.runnect.server.common.constant.TokenStatus;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.slack.SlackApi;
+import org.runnect.server.scrap.dto.response.CreateAndDeleteScrapResponseDto;
+import org.runnect.server.scrap.dto.response.GetScrapCourseResponseDto;
+import org.runnect.server.scrap.dto.response.UserResponse;
+import org.runnect.server.scrap.service.ScrapService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@WebMvcTest(ScrapController.class)
+class ScrapControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ScrapService scrapService;
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private SlackApi slackApi;
+
+    @BeforeEach
+    void setUpAuth() {
+        BDDMockito.lenient().when(jwtService.verifyToken("valid")).thenReturn(TokenStatus.TOKEN_VALID);
+        BDDMockito.lenient().when(jwtService.getJwtContents("valid")).thenReturn("1");
+    }
+
+    private <B extends MockHttpServletRequestBuilder> B withAuth(B builder) {
+        builder.header("accessToken", "valid").header("refreshToken", "valid");
+        return builder;
+    }
+
+    @Nested
+    @DisplayName("POST /api/scrap")
+    class CreateAndDeleteScrap {
+
+        @Test
+        @DisplayName("scrapTF가 true면 200과 스크랩 생성 결과를 반환한다")
+        void 스크랩_생성() throws Exception {
+            when(scrapService.createAndDeleteScrap(eq(1L), any()))
+                .thenReturn(CreateAndDeleteScrapResponseDto.of(10L, 1L, true));
+
+            mockMvc.perform(withAuth(post("/api/scrap"))
+                    .contentType("application/json")
+                    .content("{\"publicCourseId\":10,\"scrapTF\":true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.scrapTF").value(true));
+        }
+
+        @Test
+        @DisplayName("scrapTF가 false면 200과 스크랩 삭제 결과를 반환한다")
+        void 스크랩_삭제() throws Exception {
+            when(scrapService.createAndDeleteScrap(eq(1L), any()))
+                .thenReturn(CreateAndDeleteScrapResponseDto.of(10L, 0L, false));
+
+            mockMvc.perform(withAuth(post("/api/scrap"))
+                    .contentType("application/json")
+                    .content("{\"publicCourseId\":10,\"scrapTF\":false}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.scrapTF").value(false));
+        }
+
+        @Test
+        @DisplayName("publicCourseId가 없으면 400을 반환한다")
+        void 코스아이디_없음() throws Exception {
+            mockMvc.perform(withAuth(post("/api/scrap"))
+                    .contentType("application/json")
+                    .content("{\"scrapTF\":true}"))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(scrapService);
+        }
+
+        @Test
+        @DisplayName("scrapTF가 없으면 400을 반환한다")
+        void 스크랩여부_없음() throws Exception {
+            mockMvc.perform(withAuth(post("/api/scrap"))
+                    .contentType("application/json")
+                    .content("{\"publicCourseId\":10}"))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(scrapService);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/scrap/user")
+    class GetScrapCourseByUser {
+
+        @Test
+        @DisplayName("정상 요청이면 200과 스크랩 목록을 반환한다")
+        void 정상_조회() throws Exception {
+            when(scrapService.getScrapCourseByUser(1L))
+                .thenReturn(GetScrapCourseResponseDto.of(UserResponse.of(1L), Collections.emptyList()));
+
+            mockMvc.perform(withAuth(get("/api/scrap/user")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.user.userId").value(1));
+        }
+    }
+}

--- a/src/test/java/org/runnect/server/user/controller/UserStampControllerTest.java
+++ b/src/test/java/org/runnect/server/user/controller/UserStampControllerTest.java
@@ -1,0 +1,64 @@
+package org.runnect.server.user.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.runnect.server.common.constant.TokenStatus;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.slack.SlackApi;
+import org.runnect.server.user.dto.response.GetUserStampsResponseDto;
+import org.runnect.server.user.entity.RunnectUser;
+import org.runnect.server.user.entity.SocialType;
+import org.runnect.server.user.service.UserStampService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@WebMvcTest(UserStampController.class)
+class UserStampControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserStampService userStampService;
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private SlackApi slackApi;
+
+    @BeforeEach
+    void setUpAuth() {
+        BDDMockito.lenient().when(jwtService.verifyToken("valid")).thenReturn(TokenStatus.TOKEN_VALID);
+        BDDMockito.lenient().when(jwtService.getJwtContents("valid")).thenReturn("1");
+    }
+
+    private <B extends MockHttpServletRequestBuilder> B withAuth(B builder) {
+        builder.header("accessToken", "valid").header("refreshToken", "valid");
+        return builder;
+    }
+
+    @Test
+    @DisplayName("GET /api/stamp/user - 정상 요청이면 200과 유저 스탬프 목록을 반환한다")
+    void 정상_조회() throws Exception {
+        RunnectUser user = RunnectUser.builder()
+            .nickname("러너1").socialId("social-1").email("user1@runnect.io")
+            .provider(SocialType.KAKAO).build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        when(userStampService.findUserStamps(1L)).thenReturn(GetUserStampsResponseDto.from(user));
+
+        mockMvc.perform(withAuth(get("/api/stamp/user")))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.user.id").value(1))
+            .andExpect(jsonPath("$.data.stamps").isEmpty());
+    }
+}


### PR DESCRIPTION
## 작업 배경
- CourseController @WebMvcTest 파일럿(#226)에 이어, 나머지 단순 컨트롤러 5개의 라우팅/@Valid 검증/@UserId 인증/예외→HTTP 상태코드 매핑을 슬라이스 테스트로 검증한다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `health/controller/HealthControllerTest.java` (신규) | 건강 데이터 CRUD 4개 엔드포인트 (9 테스트) |
| `scrap/controller/ScrapControllerTest.java` (신규) | 스크랩 생성/삭제/조회 2개 엔드포인트 (6 테스트) |
| `banner/controller/BannerControllerTest.java` (신규) | 배너 조회 (2 테스트) |
| `user/controller/UserStampControllerTest.java` (신규) | 유저 스탬프 조회 (1 테스트) |
| `common/controller/ServerProfileControllerTest.java` (신규) | 활성 프로파일 조회 (1 테스트) |

## 영향 범위
- 테스트 전용 변경, 프로덕션 코드 변경 없음.
- 컨트롤러 레이어 자체 로직 변경 없음.

### 검증 매트릭스

| 영향 범위 | 테스트 코드 |
| --- | --- |
| POST /api/record/{id}/health 정상 생성 | • [`정상_생성`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L74) |
| POST .../health 필수값 없으면 400 | • [`필수값_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L87) |
| POST .../health 소유권 없으면 403 | • [`소유권_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L98) |
| POST .../health 중복이면 409 | • [`이미_존재`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L112) |
| GET .../health 정상 조회 | • [`정상_조회`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L131) |
| GET /api/health/summary 정상 조회 | • [`정상_조회`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L151) |
| GET /api/health/summary 파라미터 없으면 400 | • [`파라미터_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L167) |
| DELETE .../health 정상 삭제 | • [`정상_삭제`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/health/controller/HealthControllerTest.java#L181) |
| POST /api/scrap scrapTF=true 정상 생성 | • [`스크랩_생성`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/scrap/controller/ScrapControllerTest.java#L60) |
| POST /api/scrap scrapTF=false 정상 삭제 | • [`스크랩_삭제`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/scrap/controller/ScrapControllerTest.java#L73) |
| POST /api/scrap publicCourseId 없으면 400 | • [`코스아이디_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/scrap/controller/ScrapControllerTest.java#L86) |
| POST /api/scrap scrapTF 없으면 400 | • [`스크랩여부_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/scrap/controller/ScrapControllerTest.java#L97) |
| GET /api/scrap/user 정상 조회 | • [`정상_조회`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/scrap/controller/ScrapControllerTest.java#L113) |
| GET /api/banner 정상 조회 | • [`정상_조회`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/banner/controller/BannerControllerTest.java#L37) |
| GET /api/banner 빈 목록 | • [`배너_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/banner/controller/BannerControllerTest.java#L49) |
| GET /api/stamp/user 정상 조회 | • [`정상_조회`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/user/controller/UserStampControllerTest.java#L52) |
| GET /profile 활성 프로파일 반환 | • [`활성_프로파일_반환`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/de9afde787890038ee6ccdb6134c6749374867a7/src/test/java/org/runnect/server/common/controller/ServerProfileControllerTest.java#L31) |

## Test Plan
- [x] 배치 5개 컨트롤러 테스트 17/17 통과
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 213/213 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)