### PR TITLE
fix: sort 파라미터 없는 요청에서 발생하던 500 에러 수정

### DIFF
--- a/src/main/java/org/runnect/server/common/resolver/sort/SortStatusIdResolver.java
+++ b/src/main/java/org/runnect/server/common/resolver/sort/SortStatusIdResolver.java
@@ -31,8 +31,11 @@ public class SortStatusIdResolver implements HandlerMethodArgumentResolver{
     public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String queryString = request.getQueryString();
-        Map<String, List<String>> splitQuery = Util.splitQuery(queryString);
-
+        // 쿼리 파라미터가 하나도 없으면(예: ~url~/public-course) getQueryString()이 null을 반환해
+        // split()에서 NPE(500)가 나던 부분 — sort 키가 없는 경우와 동일하게 기본값으로 처리한다.
+        Map<String, List<String>> splitQuery = queryString == null
+                ? Collections.emptyMap()
+                : Util.splitQuery(queryString);
 
         if(!splitQuery.containsKey("sort") || splitQuery.get("sort").get(0)==null){
             // 1번째 조건 : ~url~/public-course


### PR DESCRIPTION
## 작업 배경
- dev에서 PublicCourseController @WebMvcTest 작성 중 발견한 실제 프로덕션 버그를 main에도 포팅한다 (dev PR #228).
- `GET /api/public-course`를 쿼리 파라미터 없이 호출하면(흔한 실제 클라이언트 호출 패턴) 500이 발생하는 버그.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `common/resolver/sort/SortStatusIdResolver.java` | `request.getQueryString()`이 null일 때(쿼리 파라미터가 전혀 없을 때) NPE로 500이 나던 버그 수정 |

## 영향 범위
- `GET /api/public-course`(퍼블릭 코스 추천/메인 피드 엔드포인트)를 쿼리 파라미터 없이 호출하면 `HttpServletRequest.getQueryString()`이 null을 반환해 `SortStatusIdResolver`가 `null.split()`으로 NPE → 500을 반환하던 버그. sort 키만 없는 경우(예: `?pageNo=1`)는 이미 정상 처리되고 있었다.
- 수정 후 쿼리 파라미터가 아예 없어도 기본 정렬("date")로 정상 처리된다. 기존에 정상 동작하던 케이스(쿼리 파라미터가 있는 경우)의 동작은 변경 없음.

## Test Plan
- [x] 로컬 컴파일 확인 (`./gradlew compileJava`)
- [x] 로컬 postgres/redis(raw docker) 기동 후 `./gradlew test` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)