### PR TITLE
test: AuthController @WebMvcTest 추가

### DIFF
--- a/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java
@@ -1,0 +1,143 @@
+package org.runnect.server.auth.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.runnect.server.auth.dto.response.GetNewTokenResponseDto;
+import org.runnect.server.auth.dto.response.SignInResponseDto;
+import org.runnect.server.auth.dto.response.SignUpResponseDto;
+import org.runnect.server.auth.service.AuthService;
+import org.runnect.server.common.constant.ErrorStatus;
+import org.runnect.server.config.jwt.JwtService;
+import org.runnect.server.config.slack.SlackApi;
+import org.runnect.server.user.exception.authException.InvalidRefreshTokenException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private SlackApi slackApi;
+
+    @Nested
+    @DisplayName("POST /api/auth")
+    class SignIn {
+
+        @Test
+        @DisplayName("기존 유저면 200과 LOGIN 응답을 반환한다")
+        void 기존_유저_로그인() throws Exception {
+            when(authService.signIn(BDDMockito.any())).thenReturn(
+                SignInResponseDto.of("KAKAO", "user@runnect.io", "access-token", "refresh-token"));
+
+            mockMvc.perform(post("/api/auth")
+                    .contentType("application/json")
+                    .content("{\"token\":\"kakao-token\",\"provider\":\"kakao\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value("user@runnect.io"));
+        }
+
+        @Test
+        @DisplayName("신규 유저면 200과 SIGNUP 응답을 반환한다")
+        void 신규_유저_회원가입() throws Exception {
+            when(authService.signIn(BDDMockito.any())).thenReturn(
+                SignUpResponseDto.of("KAKAO", "new@runnect.io", "러너1", "access-token", "refresh-token"));
+
+            mockMvc.perform(post("/api/auth")
+                    .contentType("application/json")
+                    .content("{\"token\":\"kakao-token\",\"provider\":\"kakao\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("러너1"));
+        }
+
+        @Test
+        @DisplayName("token이 없으면 400을 반환한다")
+        void 토큰_없음() throws Exception {
+            mockMvc.perform(post("/api/auth")
+                    .contentType("application/json")
+                    .content("{\"provider\":\"kakao\"}"))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(authService);
+        }
+
+        @Test
+        @DisplayName("provider가 없으면 400을 반환한다")
+        void 프로바이더_없음() throws Exception {
+            mockMvc.perform(post("/api/auth")
+                    .contentType("application/json")
+                    .content("{\"token\":\"kakao-token\"}"))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(authService);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/auth/getNewToken")
+    class GetNewToken {
+
+        @Test
+        @DisplayName("정상 요청이면 200과 재발급된 토큰을 반환한다")
+        void 정상_재발급() throws Exception {
+            when(authService.getNewToken("old-access", "valid-refresh"))
+                .thenReturn(GetNewTokenResponseDto.of("new-access", "new-refresh"));
+
+            mockMvc.perform(get("/api/auth/getNewToken")
+                    .header("accessToken", "old-access")
+                    .header("refreshToken", "valid-refresh"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("new-access"));
+        }
+
+        @Test
+        @DisplayName("refreshToken 헤더가 없으면 400을 반환한다")
+        void 리프레시토큰_헤더_없음() throws Exception {
+            mockMvc.perform(get("/api/auth/getNewToken").header("accessToken", "old-access"))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(authService);
+        }
+
+        @Test
+        @DisplayName("refreshToken이 빈 문자열이면 400을 반환한다")
+        void 리프레시토큰_빈문자열() throws Exception {
+            mockMvc.perform(get("/api/auth/getNewToken")
+                    .header("accessToken", "old-access")
+                    .header("refreshToken", ""))
+                .andExpect(status().isBadRequest());
+
+            BDDMockito.verifyNoInteractions(authService);
+        }
+
+        @Test
+        @DisplayName("저장된 리프레시 토큰과 일치하지 않으면 401을 반환한다")
+        void 리프레시토큰_불일치() throws Exception {
+            when(authService.getNewToken("old-access", "wrong-refresh"))
+                .thenThrow(new InvalidRefreshTokenException(
+                    ErrorStatus.INVALID_REFRESH_TOKEN_EXCEPTION,
+                    ErrorStatus.INVALID_REFRESH_TOKEN_EXCEPTION.getMessage()));
+
+            mockMvc.perform(get("/api/auth/getNewToken")
+                    .header("accessToken", "old-access")
+                    .header("refreshToken", "wrong-refresh"))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+}


### PR DESCRIPTION
## 작업 배경
- 컨트롤러 @WebMvcTest 스윕의 마지막 배치. AuthController의 로그인/회원가입 분기 로직과 토큰 재발급의 라우팅/@Validated 검증/예외→HTTP 상태코드 매핑을 검증한다.
- 이로써 서비스 레이어(11개 서비스) + 컨트롤러 레이어(8개 컨트롤러) 전 계층 테스트가 갖춰졌다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `auth/controller/AuthControllerTest.java` (신규) | 로그인/토큰재발급 2개 엔드포인트 (8 테스트) |

## 영향 범위
- 테스트 전용 변경, 프로덕션 코드 변경 없음.
- `signIn`이 서비스 응답 타입(`SignInResponseDto` vs `SignUpResponseDto`)에 따라 LOGIN/SIGNUP 성공 메시지를 분기하는 컨트롤러 자체 로직을 실제로 검증한다.
- AuthController는 클래스에 `@Validated`가 있어(다른 컨트롤러들과 달리) `@RequestHeader`의 `@NotBlank`가 실제로 동작함을 확인했다.

### 검증 매트릭스

| 영향 범위 | 테스트 코드 |
| --- | --- |
| POST /api/auth 기존 유저 로그인 분기 | • [`기존_유저_로그인`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L45) |
| POST /api/auth 신규 유저 회원가입 분기 | • [`신규_유저_회원가입`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L58) |
| POST /api/auth token 없으면 400 | • [`토큰_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L71) |
| POST /api/auth provider 없으면 400 | • [`프로바이더_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L82) |
| GET /api/auth/getNewToken 정상 재발급 | • [`정상_재발급`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L98) |
| GET /api/auth/getNewToken refreshToken 헤더 없으면 400 | • [`리프레시토큰_헤더_없음`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L111) |
| GET /api/auth/getNewToken refreshToken 빈 문자열이면 400 | • [`리프레시토큰_빈문자열`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L120) |
| GET /api/auth/getNewToken 토큰 불일치면 401 | • [`리프레시토큰_불일치`](https://github.com/Runnect/Runnect-Spring-Boot-Server/blob/57a6614abc772f5b6b7f5924b27164e46679c8b5/src/test/java/org/runnect/server/auth/controller/AuthControllerTest.java#L131) |

## Test Plan
- [x] AuthControllerTest 8/8 통과
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 251/251 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)