### PR TITLE
feat: springdoc-openapi로 Swagger API 문서 자동화 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
 	// Sentry
 	implementation 'io.sentry:sentry-spring-boot-starter:4.3.0'
 
+	// Swagger (OpenAPI)
+	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/runnect/server/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/runnect/server/config/swagger/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package org.runnect.server.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+    private static final String REFRESH_TOKEN_HEADER = "refreshToken";
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme accessTokenScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name(ACCESS_TOKEN_HEADER);
+
+        SecurityScheme refreshTokenScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name(REFRESH_TOKEN_HEADER);
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList(ACCESS_TOKEN_HEADER)
+                .addList(REFRESH_TOKEN_HEADER);
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Runnect API")
+                        .description("Runnect 서버 API 문서")
+                        .version("v1"))
+                .components(new Components()
+                        .addSecuritySchemes(ACCESS_TOKEN_HEADER, accessTokenScheme)
+                        .addSecuritySchemes(REFRESH_TOKEN_HEADER, refreshTokenScheme))
+                .addSecurityItem(securityRequirement);
+    }
+}


### PR DESCRIPTION
## 작업 배경
- 컨트롤러 @WebMvcTest 스윕이 끝나 API 스펙(요청/응답 DTO, 검증 규칙)이 안정된 지금이 API 문서화 도입에 적합한 시점이라 판단해 진행한다.
- 지금까지 API 스펙은 코드를 직접 읽어야만 확인 가능했음 — Swagger로 자동 생성/시각화한다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `build.gradle` | `springdoc-openapi-ui:1.7.0` 의존성 추가 (Spring Boot 2.7.x / javax 네임스페이스와 호환되는 1.x 최종 버전) |
| `config/swagger/SwaggerConfig.java` (신규) | OpenAPI 메타 정보 + `accessToken`/`refreshToken` 커스텀 헤더 인증을 위한 SecurityScheme 구성 |

## 영향 범위
- 기존 컨트롤러/DTO에 별도 애노테이션 없이 자동으로 스펙이 생성됨 — 기존 코드 변경 없음, 런타임 동작 변경 없음.
- `/swagger-ui/index.html`에서 전체 API(10개 컨트롤러, 26개 엔드포인트) 확인 가능. `/v3/api-docs`로 OpenAPI 3.0 JSON 스펙도 제공.
- 이 프로젝트는 표준 `Authorization: Bearer` 대신 `accessToken`/`refreshToken` 커스텀 헤더로 인증하므로, Swagger UI의 "Authorize"에서 두 헤더 값을 직접 입력해 바로 API를 테스트할 수 있도록 구성했다 (스크린샷 참고).

## Test Plan
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 251/251 통과 (신규 의존성이 슬라이스 테스트 컨텍스트 로딩에 영향 없음 확인)
- [x] 로컬 서버 기동 후 브라우저로 `/swagger-ui/index.html` 직접 확인 — 전체 엔드포인트 정상 렌더링, Authorize 모달에서 accessToken/refreshToken 헤더 입력 필드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)