### PR TITLE
fix: 코스 생성 시 GPS 경로 전체를 로그에 남기던 코드 제거 (dev)

### DIFF
--- a/src/main/java/org/runnect/server/common/module/convert/CoordinatePathConverter.java
+++ b/src/main/java/org/runnect/server/common/module/convert/CoordinatePathConverter.java
@@ -18,8 +18,7 @@ public class CoordinatePathConverter {
         try {
             return getLineString(path);
         } catch (Exception e) {
-            log.warn("course 요청 데이터 값 (path) -> " + path);
-            log.warn("course 요청 데이터 값의 타입 (path) -> " + path.getClass().getName());
+            log.warn("course 요청 데이터 변환 실패 (size={}, type={}): {}", path.size(), path.getClass().getName(), e.getMessage());
             throw new BadRequestException(ErrorStatus.VALIDATION_COURSE_PATH_EXCEPTION, ErrorStatus.VALIDATION_COURSE_PATH_EXCEPTION.getMessage());
         }
     }
@@ -43,16 +42,11 @@ public class CoordinatePathConverter {
     }
 
     private static LineString getLineString(List<CoordinateDto> coordinateDtos) {
-        StringBuilder sb = new StringBuilder();
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
         Coordinate[] coordinates = new Coordinate[coordinateDtos.size()];
         for (int i = 0; i < coordinateDtos.size(); i++) {
             coordinates[i] = new Coordinate(coordinateDtos.get(i).getLatitude(), coordinateDtos.get(i).getLongitude());
-            sb.append("(" + coordinateDtos.get(i).getLatitude() + ", " + coordinateDtos.get(i).getLongitude() + ")");
         }
-        LineString lineString = geometryFactory.createLineString(coordinates);
-        log.info("create course!");
-        log.info(sb.toString());
-        return lineString;
+        return geometryFactory.createLineString(coordinates);
     }
 }


### PR DESCRIPTION
## 작업 배경
dev/main 브랜치 정합성을 점검하다가, 개인정보(GPS 경로) 로깅 관련 실제 취약점을 발견했다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `CoordinatePathConverter.java` | 코스 생성 시 유저의 실제 GPS 좌표 전체를 `log.info`로 남기던 코드 제거, main의 안전한 버전으로 교체 |

## 영향 범위
- **보안/개인정보 이슈**: main엔 이미 `fix/course-path-log-pii`(#200)로 이 문제가 수정됐는데, dev는 그 수정을 반영받지 못했을 뿐 아니라 오히려 좌표 전체(`(lat, lng)` 쌍 전부)를 `log.info(sb.toString())`으로 명시적으로 남기는 코드가 추가돼 있었음 — **지금 dev 환경에서 코스를 생성할 때마다 유저의 실제 러닝 경로가 서버 로그에 그대로 남고 있던 상태**.
- 수정 후에는 변환 실패 시에도 좌표값 자체가 아니라 `size`/`type`/에러 메시지만 로그에 남도록 main과 동일하게 맞춤 — 정상 동작(로직 자체)은 변경 없음.

## Test Plan
- [x] `./gradlew compileJava` 성공
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 251/251 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning messages when course paths cannot be converted, including relevant path details and the error message.
  * Reduced unnecessary logging during course-path processing for cleaner system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->