### PR TITLE
fix: 공개 코스 쓰기 작업 시 관련 캐시 즉시 무효화 (dev)

### DIFF
--- a/src/main/java/org/runnect/server/course/service/CourseService.java
+++ b/src/main/java/org/runnect/server/course/service/CourseService.java
@@ -27,6 +27,7 @@ import org.runnect.server.user.entity.StampType;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
 import org.runnect.server.user.repository.UserRepository;
 import org.runnect.server.user.service.UserStampService;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -136,6 +137,9 @@ public class CourseService {
         return UpdateCourseResponseDto.of(course);
     }
 
+    // 조건부로 공개 코스가 같이 삭제될 수 있어(비공개 코스면 스킵), 매번 무효화해도
+    // 안전한 쪽(과다 무효화)을 택함 — 공개 코스 목록 캐시(전체페이지수/마라톤/추천) 대상
+    @CacheEvict(value = {"publicCourseTotalPageCount", "marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public DeleteCoursesResponseDto deleteCourses(List<Long> courseIdList, Long userId) {
         courseIdList.forEach(courseId -> {

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -39,6 +39,7 @@ import org.runnect.server.user.entity.RunnectUser;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
 import org.runnect.server.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -304,6 +305,9 @@ public class PublicCourseService {
 
     }
 
+    // 코스 목록에 영향을 주는 쓰기 작업이라, 작성자 본인 캐시만이 아니라
+    // 전체 유저가 보는 목록 캐시(전체페이지수/마라톤/추천)를 다 지워야 함
+    @CacheEvict(value = {"publicCourseTotalPageCount", "marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public CreatePublicCourseResponseDto createPublicCourse(
             final Long userId,
@@ -348,6 +352,7 @@ public class PublicCourseService {
 
     }
 
+    @CacheEvict(value = {"publicCourseTotalPageCount", "marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public DeletePublicCoursesResponseDto deletePublicCourses(
             Long userId,
@@ -393,6 +398,8 @@ public class PublicCourseService {
         return DeletePublicCoursesResponseDto.from(publicCourses.size());
     }
 
+    // 제목/설명만 바뀌고 코스 개수는 그대로라 전체페이지수 캐시는 지울 필요 없음
+    @CacheEvict(value = {"marathonPublicCourse", "recommendPublicCourse"}, allEntries = true)
     @Transactional
     public UpdatePublicCourseResponseDto updatePublicCourse(Long userId, Long publicCourseId, String title, String description) {
         PublicCourse publicCourse = publicCourseRepository.findById(publicCourseId)


### PR DESCRIPTION
## 작업 배경
dev/main 브랜치 정합성을 점검하다가, main엔 이미 반영된 캐시 무효화 로직(#208)이 dev엔 빠져있는 걸 발견했다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `CourseService.deleteCourses` | 캐시 무효화 추가 (조건부로 공개 코스도 같이 삭제될 수 있어 매번 무효화) |
| `PublicCourseService.createPublicCourse` / `deletePublicCourses` / `updatePublicCourse` | 각각 영향받는 목록 캐시 무효화 추가 |

## 영향 범위
- dev는 조회 캐싱(`@Cacheable`, TTL 1분)만 있고 무효화(`@CacheEvict`)가 없어서, **코스를 추가/삭제하거나 공개 코스를 수정해도 최대 1분간 오래된 목록이 그대로 보이던 문제**가 있었음.
- main의 검증된 로직을 그대로 포팅 — 로직 변경 없이 동일하게 반영.

## Test Plan
- [x] `./gradlew compileJava` 성공, dev 브랜치의 두 파일이 main과 완전히 동일함을 `git diff origin/main`으로 확인
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 251/251 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)