### PR TITLE
hotfix: Render staging 배포 실패 복구 — Dockerfile 복원

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# --- Build stage ---
+FROM gradle:8.2.1-jdk11 AS build
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY gradlew ./
+
+COPY src ./src
+
+# 로컬/모니터링 검증용 application.yml은 build context 루트에 두고 복사한다.
+# (CI/CD에서는 GitHub Secret으로 별도 생성 — 이 Dockerfile은 로컬 검증 전용)
+COPY application.yml ./application.yml
+
+RUN ./gradlew bootJar -x test --no-daemon
+
+# --- Run stage ---
+FROM eclipse-temurin:11-jre
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+COPY --from=build /app/application.yml application.yml
+
+EXPOSE 8080
+
+# dev(Render Free tier, 512MB)는 메모리 여유가 없어 OTel agent를 뺀다.
+# prod는 CD가 이 Dockerfile을 쓰지 않으므로(별도 CodeDeploy) 영향 없음.
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar", "--spring.config.location=file:./application.yml"]


### PR DESCRIPTION
## 작업 배경
Render staging 배포가 실패했다 (`error: failed to read dockerfile: open Dockerfile: no such file or directory`, [deploy log](https://dashboard.render.com/web/srv-d9hjoh67r5hc738ki2g0/deploys/dep-d9td3jc9v7es73brq44g)).

원인: `main`엔 원래 `Dockerfile`이 없었다 — 트렁크 기반 전환 때 dev/main 콘텐츠 정합화를 하면서 `Dockerfile`을 "로컬 검증 전용"으로 오판해 main에 옮기지 않았다. 그런데 Render 대시보드의 Docker Command 오버라이드는 빌드된 이미지의 **실행 커맨드**만 바꾸는 것이고, 이미지 자체는 이 Dockerfile로 빌드해왔다. `dev` 브랜치 삭제 + Render 배포 브랜치를 `main`으로 전환하면서 Dockerfile을 못 찾아 빌드가 즉시 실패했다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `Dockerfile` (신규) | dev의 마지막 버전(OTel agent 제거 이후) 그대로 복원 |

## 영향 범위
- Render staging 빌드만 영향. AWS CodeDeploy 기반 상용 배포(`prod-cd.yml`)는 이 Dockerfile을 쓰지 않아 무관.
- 병합 즉시 Render에서 재배포 트리거해서 실제로 뜨는지 확인 필요.

## Test Plan
- [x] `git cat-file`로 dev 마지막 커밋의 Dockerfile 내용 그대로 복원했음을 확인 (diff 없음)
- [ ] 병합 후 Render 재배포 성공 확인 (수동 확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)