### PR TITLE
feat: 요청 추적용 MDC traceId/userId 로깅 main에 포팅

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -35,7 +35,7 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        mkdir ./src/main/resources
+        mkdir -p ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: make application.properties 파일 생성
         run: |
           ## create application.yml
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           
           # application.yml 파일 생성

--- a/src/main/java/org/runnect/server/common/resolver/userId/UserIdResolver.java
+++ b/src/main/java/org/runnect/server/common/resolver/userId/UserIdResolver.java
@@ -4,6 +4,7 @@ package org.runnect.server.common.resolver.userId;
 import org.runnect.server.common.constant.TokenStatus;
 import org.runnect.server.common.constant.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
 import org.runnect.server.common.module.check.TypeChecker;
 import org.runnect.server.user.exception.authException.InvalidAccessTokenException;
 import org.runnect.server.user.exception.authException.NullAccessTokenException;
@@ -76,6 +77,7 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
                 && request.getMethod().equals("GET")
                 && VISITOR_POSSIBLE_URLS.contains(removeLastPathSegment(request.getRequestURI()))){
             // 방문자모드 허용 api에 대한 요청이 맞는지 검증
+            MDC.put("userId", String.valueOf(VISITOR_ID));
             return VISITOR_ID;
         }
 
@@ -92,7 +94,9 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
         final String tokenContents = jwtService.getJwtContents(accessToken);
 
         try {
-            return Long.parseLong(tokenContents);
+            Long userId = Long.parseLong(tokenContents);
+            MDC.put("userId", String.valueOf(userId));
+            return userId;
         } catch (NumberFormatException e) {
             throw new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION, ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage());
         }

--- a/src/main/java/org/runnect/server/config/logging/MdcLoggingFilter.java
+++ b/src/main/java/org/runnect/server/config/logging/MdcLoggingFilter.java
@@ -1,0 +1,68 @@
+package org.runnect.server.config.logging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.runnect.server.common.constant.TokenStatus;
+import org.runnect.server.config.jwt.JwtService;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * 요청마다 traceId를 발급해 MDC에 담아둔다.
+ * 로그 패턴에 %X{traceId}를 포함시키면(logback-spring.xml), 여러 요청이 뒤섞인 로그에서도
+ * 같은 traceId로 특정 요청의 흐름만 추적할 수 있다.
+ *
+ * userId는 @UserId 파라미터가 없는 요청(토큰 재발급, 배너 등)에서도 로그에 남도록
+ * 여기서 best-effort로 한 번 더 채운다. 실제 인증 검증/방문자 모드 처리는 UserIdResolver가
+ * 맡고, 그 결과가 이후 이 값을 덮어쓴다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MdcLoggingFilter implements Filter {
+
+    private static final String TRACE_ID_KEY = "traceId";
+    private static final int TRACE_ID_LENGTH = 8;
+    private static final String USER_ID_KEY = "userId";
+
+    private final JwtService jwtService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String traceId = UUID.randomUUID().toString().substring(0, TRACE_ID_LENGTH);
+        try {
+            MDC.put(TRACE_ID_KEY, traceId);
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            populateUserIdBestEffort(httpRequest);
+            log.info("{} {}", httpRequest.getMethod(), httpRequest.getRequestURI());
+            chain.doFilter(request, response);
+        } finally {
+            MDC.remove(TRACE_ID_KEY);
+            MDC.remove(USER_ID_KEY);
+        }
+    }
+
+    private void populateUserIdBestEffort(HttpServletRequest request) {
+        String accessToken = request.getHeader("accessToken");
+        if (accessToken == null) {
+            return;
+        }
+        try {
+            if (jwtService.verifyToken(accessToken) == TokenStatus.TOKEN_VALID) {
+                MDC.put(USER_ID_KEY, jwtService.getJwtContents(accessToken));
+            }
+        } catch (RuntimeException e) {
+            // 로깅 목적의 best-effort 파싱이므로 실패해도 요청 처리는 계속 진행한다.
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_DIR" value="./logs"/>
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{traceId}] [userId=%X{userId}] %-5level [%thread] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/runnect-server.log</file>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/runnect-server.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+</configuration>

--- a/src/test/java/org/runnect/server/common/resolver/userId/UserIdResolverTest.java
+++ b/src/test/java/org/runnect/server/common/resolver/userId/UserIdResolverTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.runnect.server.common.constant.TokenStatus;
@@ -15,6 +16,7 @@ import org.runnect.server.user.exception.authException.InvalidAccessTokenExcepti
 import org.runnect.server.user.exception.authException.NullAccessTokenException;
 import org.runnect.server.user.exception.authException.TimeExpiredAccessTokenException;
 import org.runnect.server.user.exception.userException.NotFoundUserException;
+import org.slf4j.MDC;
 import org.springframework.core.MethodParameter;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -34,6 +36,11 @@ class UserIdResolverTest {
         ReflectionTestUtils.setField(userIdResolver, "VISITOR_ID", VISITOR_ID);
         ReflectionTestUtils.invokeMethod(userIdResolver, "setVISITOR_POSSIBLE_URLS", "/api/public-course");
         methodParameter = mock(MethodParameter.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
     }
 
     private NativeWebRequest webRequestWith(String accessToken, String refreshToken, String method, String uri) {
@@ -65,12 +72,13 @@ class UserIdResolverTest {
     }
 
     @Test
-    void 방문자_모드_허용_URL이면_VISITOR_ID를_반환한다() {
+    void 방문자_모드_허용_URL이면_VISITOR_ID를_반환하고_MDC에_채운다() {
         NativeWebRequest webRequest = webRequestWith("visitor", "visitor", "GET", "/api/public-course/123");
 
         Object result = userIdResolver.resolveArgument(methodParameter, null, webRequest, null);
 
         assertThat(result).isEqualTo(VISITOR_ID);
+        assertThat(MDC.get("userId")).isEqualTo(String.valueOf(VISITOR_ID));
     }
 
     @Test
@@ -92,7 +100,7 @@ class UserIdResolverTest {
     }
 
     @Test
-    void 유효한_토큰이면_userId를_반환한다() {
+    void 유효한_토큰이면_userId를_반환하고_MDC에_채운다() {
         when(jwtService.verifyToken("valid")).thenReturn(TokenStatus.TOKEN_VALID);
         when(jwtService.getJwtContents("valid")).thenReturn("42");
         NativeWebRequest webRequest = webRequestWith("valid", "refresh", "GET", "/api/user");
@@ -100,6 +108,7 @@ class UserIdResolverTest {
         Object result = userIdResolver.resolveArgument(methodParameter, null, webRequest, null);
 
         assertThat(result).isEqualTo(42L);
+        assertThat(MDC.get("userId")).isEqualTo("42");
     }
 
     @Test


### PR DESCRIPTION
## 작업 배경
dev에서 검증됐던 요청 추적 로깅(MdcLoggingFilter + logback-spring.xml)이 트렁크 기반 전환 콘텐츠 정합화 때 "로컬 모니터링 스택 전용"으로 오판되어 main에 없었다. 실제로는 ELK 연동 없이도 독립적으로 동작하는(콘솔+파일 appender만 사용) 순수 로깅 기능이라 포팅한다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `config/logging/MdcLoggingFilter.java` (신규) | 요청마다 8자리 traceId 발급 + JWT 헤더로 best-effort userId 채움, `finally`에서 반드시 MDC.remove (톰캣 스레드 재사용 시 이전 요청 값 누수 방지) |
| `resources/logback-spring.xml` (신규) | 로그 패턴에 `%X{traceId}` 포함, Console + RollingFile(30일 보관, gzip 압축) appender |
| `common/resolver/userId/UserIdResolver.java` | 실제 인증 검증을 거친 요청은 이 클래스가 더 정확한 userId로 MDC 값을 덮어쓰도록 `MDC.put` 추가 |
| `common/resolver/userId/UserIdResolverTest.java` | MDC에 값이 채워지는지 검증하는 assertion 추가, 테스트 격리를 위한 `@AfterEach MDC.clear()` |

## 영향 범위
- 로그 출력 포맷/보관 방식만 바뀜 — API 응답/비즈니스 로직 변화 없음
- `./logs` 디렉터리에 롤링 로그 파일이 쌓이기 시작함 (30일 보관 후 자동 삭제)

## Test Plan
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 254/254 통과
- [x] 로컬 실행 로그에서 `[traceId] [userId=]` 패턴이 실제로 찍히는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)