### PR TITLE
ci: 상용 배포 트리거를 main push에서 git tag(v*)로 분리

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -2,10 +2,12 @@
 name: RUNNECT-PROD-CD
 
 # 해당 workflow가 언제 실행될 것인지에 대한 트리거를 지정
-# push시에 실행
+# v로 시작하는 태그가 push될 때만 실행 (예: v1.3.0)
+# main push마다 자동으로 상용까지 나가지 않도록, 상용 배포는 태그로 명시적으로 트리거한다.
+# staging(Render)은 main push에 그대로 자동 배포된다 — staging에서 먼저 확인 후 태그를 찍는 흐름.
 on:
   push:
-    branches: [ main ] # main branch로 push 될 때 실행됩니다.
+    tags: [ 'v*' ]
 
 env:
   S3_BUCKET_NAME: runnect-prod-bucket-604764467555-ap-northeast-2-an

--- a/README.md
+++ b/README.md
@@ -165,7 +165,18 @@
   - 미완성 기능은 브랜치를 오래 살려두지 말고, feature flag로 감싸 `main`에 빠르게 합친다
 - 리뷰 완료 후 squash merge, 병합된 branch는 삭제
 
-과거에는 `dev`/`main` 두 개의 장수 branch를 cherry-pick으로 동기화하는 방식이었으나, 두 branch가 내용상 계속 어긋나는 문제(cherry-pick hell)가 반복되어 폐기했다. staging 배포도 `main` push를 기준으로 트리거된다.
+과거에는 `dev`/`main` 두 개의 장수 branch를 cherry-pick으로 동기화하는 방식이었으나, 두 branch가 내용상 계속 어긋나는 문제(cherry-pick hell)가 반복되어 폐기했다.
+
+### 🚀 배포 전략 (Continuous Delivery)
+
+`main`은 항상 배포 가능한 상태를 유지하되, staging과 상용의 배포 트리거는 분리했다 — merge 즉시 상용까지 나가면 검증 없이 바로 노출되는 문제가 있어서다.
+
+| 환경 | 트리거 | 방식 |
+| --- | --- | --- |
+| staging (Render) | `main` push | 자동 배포 |
+| 상용 (AWS CodeDeploy) | `v*` 형식의 git tag push | 수동 승격 |
+
+merge → staging에서 자동 확인 → 문제 없으면 `git tag v1.x.x && git push origin v1.x.x`로 상용 배포. 버전은 느슨한 semver(기능 추가 minor, 버그 수정 patch)를 따른다.
 
 ### 🚩 Feature Flag
 


### PR DESCRIPTION
## 작업 배경
Trunk-Based Development 전환(#236) 이후 staging(Render)과 상용(AWS CodeDeploy)이 둘 다 `main` push에 트리거돼서, merge하면 검증 없이 바로 상용까지 나가는 문제가 있었다. Continuous Delivery 패턴(merge는 항상 배포 가능한 상태만 보장, 상용 반영은 명시적 트리거)으로 분리한다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `prod-cd.yml` | 트리거를 `push: branches: [main]` → `push: tags: ['v*']`로 변경 |
| `README.md` | 배포 전략 섹션 추가 (staging/상용 트리거 분리 표, 태그 배포 절차) |

## 영향 범위
- **이후로는 `main`에 push/merge해도 상용에 자동 반영되지 않는다.** staging은 그대로 자동 배포됨.
- 상용에 반영하려면 `git tag v1.x.x && git push origin v1.x.x` 필요.
- staging 배포(Render)는 이 PR과 무관 — 별도로 Render 대시보드 배포 트리거 branch를 `dev`→`main`으로 바꿔야 함(진행 중).

## Test Plan
- [x] YAML 문법 확인 (`build` CI 통과로 workflow 파일 자체는 파싱됨)
- [ ] 실제 태그 push로 상용 배포가 트리거되는지는 다음 릴리즈 때 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)