### PR TITLE
ci: 상용 배포용 태그 자동 생성 워크플로 추가 (Promote to Production)

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -1,0 +1,69 @@
+# GitHub Actions 탭에서 버튼 한 번으로 상용 배포를 트리거하기 위한 워크플로.
+# main의 다음 semver 태그(v1.2.3 형태)를 자동으로 계산해 push하고,
+# 그 태그 push가 prod-cd.yml의 트리거(on.push.tags)를 실행시켜 상용 배포로 이어진다.
+name: Promote to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "버전 증가 단위"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 다음 버전 태그 계산
+        id: version
+        run: |
+          git fetch --tags
+          LATEST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+          fi
+          echo "현재 최신 태그: $LATEST"
+
+          VERSION=${LATEST#v}
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          case "${{ inputs.bump }}" in
+            major)
+              MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1)); PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "새 태그: $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: 태그 생성 및 push (→ prod-cd.yml 트리거)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.new_tag }}"
+          git push origin "${{ steps.version.outputs.new_tag }}"
+
+      - name: 요약
+        run: echo "## ${{ steps.version.outputs.new_tag }} 태그 push 완료 — RUNNECT-PROD-CD가 곧 트리거됩니다." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -176,7 +176,14 @@
 | staging (Render) | `main` push | 자동 배포 |
 | 상용 (AWS CodeDeploy) | `v*` 형식의 git tag push | 수동 승격 |
 
-merge → staging에서 자동 확인 → 문제 없으면 `git tag v1.x.x && git push origin v1.x.x`로 상용 배포. 버전은 느슨한 semver(기능 추가 minor, 버그 수정 patch)를 따른다.
+merge → staging에서 자동 확인 → 문제 없으면 상용 배포. 태그를 로컬에서 직접 만들 필요 없이, **GitHub Actions의 `Promote to Production` workflow**(`workflow_dispatch`)를 실행하면 다음 semver 태그를 자동 계산해 push까지 해준다.
+
+```bash
+# Actions 탭에서 "Promote to Production" → Run workflow 버튼으로도 가능
+gh workflow run promote-to-prod.yml -f bump=patch   # patch | minor | major
+```
+
+이 태그 push가 `prod-cd.yml`의 트리거를 실행시켜 상용 배포로 이어진다.
 
 ### 🚩 Feature Flag
 


### PR DESCRIPTION
## 작업 배경
#240에서 상용 배포를 `git tag v1.x.x && git push origin v1.x.x`로 수동 트리거하도록 분리했는데, 매번 로컬에서 이 커맨드를 직접 입력하는 게 번거롭다는 피드백을 받았다. GitHub Actions 버튼(또는 CLI 한 줄)으로 대체한다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `.github/workflows/promote-to-prod.yml` (신규) | `workflow_dispatch`(bump: patch/minor/major 선택) — 최신 `v*` 태그를 조회해 다음 semver를 계산하고 태그 생성/push까지 자동 수행 |
| `README.md` | 배포 전략 섹션에 `gh workflow run promote-to-prod.yml -f bump=patch` 사용법 추가 |

## 영향 범위
- 이 워크플로가 push하는 태그가 `prod-cd.yml`의 트리거를 실행시켜 상용 배포로 이어짐 — 즉 이 워크플로를 실행하면 실제로 상용에 배포됨
- `permissions: contents: write`로 GITHUB_TOKEN에 태그 push 권한 부여 (다른 권한 확장 없음)

## Test Plan
- [x] YAML 문법 검증 (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] 실제 Actions 탭에서 실행해 태그 생성 → prod-cd.yml 트리거까지 확인 필요 (다음 릴리즈 때)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered production promotion workflow with patch, minor, and major version options.
  * Automatically creates the next version tag and initiates production deployment.

* **Documentation**
  * Updated deployment instructions with workflow usage through the command line and web interface.
  * Removed outdated manual tag creation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->