### PR TITLE
fix: promote-to-prod가 GITHUB_TOKEN 연쇄 트리거 제약에 막히던 문제 수정

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -5,9 +5,15 @@ name: RUNNECT-PROD-CD
 # v로 시작하는 태그가 push될 때만 실행 (예: v1.3.0)
 # main push마다 자동으로 상용까지 나가지 않도록, 상용 배포는 태그로 명시적으로 트리거한다.
 # staging(Render)은 main push에 그대로 자동 배포된다 — staging에서 먼저 확인 후 태그를 찍는 흐름.
+#
+# workflow_dispatch도 함께 열어둔 이유: GitHub Actions는 기본 GITHUB_TOKEN으로
+# push된 이벤트가 다른 워크플로를 연쇄 트리거하지 않도록 막아둔다(무한루프 방지).
+# promote-to-prod.yml이 GITHUB_TOKEN으로 태그를 push해도 이 push 트리거가 안 켜지므로,
+# promote-to-prod.yml이 태그 push 직후 이 workflow_dispatch를 명시적으로 호출해 우회한다.
 on:
   push:
     tags: [ 'v*' ]
+  workflow_dispatch:
 
 env:
   S3_BUCKET_NAME: runnect-prod-bucket-604764467555-ap-northeast-2-an

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -1,6 +1,11 @@
 # GitHub Actions 탭에서 버튼 한 번으로 상용 배포를 트리거하기 위한 워크플로.
-# main의 다음 semver 태그(v1.2.3 형태)를 자동으로 계산해 push하고,
-# 그 태그 push가 prod-cd.yml의 트리거(on.push.tags)를 실행시켜 상용 배포로 이어진다.
+# main의 다음 semver 태그(v1.2.3 형태)를 자동으로 계산해 push한 뒤,
+# prod-cd.yml을 workflow_dispatch로 직접 호출해 상용 배포로 이어지게 한다.
+#
+# 태그 push만으로 prod-cd.yml을 트리거하지 않는 이유: GitHub Actions는
+# 기본 GITHUB_TOKEN으로 push된 이벤트가 다른 워크플로를 연쇄 실행시키지
+# 않도록 막아둔다(무한루프 방지). 그래서 이 워크플로가 태그를 push해도
+# prod-cd.yml의 push 트리거는 켜지지 않아 명시적으로 호출해줘야 한다.
 name: Promote to Production
 
 on:
@@ -18,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:
@@ -58,12 +64,17 @@ jobs:
           echo "새 태그: $NEW_TAG"
           echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 
-      - name: 태그 생성 및 push (→ prod-cd.yml 트리거)
+      - name: 태그 생성 및 push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${{ steps.version.outputs.new_tag }}"
           git push origin "${{ steps.version.outputs.new_tag }}"
 
+      - name: RUNNECT-PROD-CD 직접 트리거
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run prod-cd.yml --ref "${{ steps.version.outputs.new_tag }}"
+
       - name: 요약
-        run: echo "## ${{ steps.version.outputs.new_tag }} 태그 push 완료 — RUNNECT-PROD-CD가 곧 트리거됩니다." >> "$GITHUB_STEP_SUMMARY"
+        run: echo "## ${{ steps.version.outputs.new_tag }} 태그 push 완료, RUNNECT-PROD-CD 트리거함" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 작업 배경
#241 머지 직후 `v0.0.1`로 실제 테스트했는데, 태그는 정상 push됐지만 `prod-cd.yml`이 트리거되지 않았다. 원인: GitHub Actions는 기본 `GITHUB_TOKEN`으로 push된 이벤트가 다른 워크플로를 연쇄 실행시키지 않도록 막아둔다(무한루프 방지) — `promote-to-prod.yml`이 정확히 이 케이스였다.

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `prod-cd.yml` | `on.workflow_dispatch` 트리거 추가 (기존 `on.push.tags`는 유지 — 로컬에서 직접 태그 push하는 경우 대비) |
| `promote-to-prod.yml` | 태그 push 직후 `gh workflow run prod-cd.yml --ref <태그>`로 명시적 호출 추가, `permissions.actions: write` 추가 |

## 영향 범위
- `Promote to Production` 워크플로를 실행해야만 발생하는 변경 — 다른 워크플로/배포 경로에 영향 없음

## Test Plan
- [x] YAML 문법 검증
- [ ] 실제로 `Promote to Production` 재실행해서 `prod-cd.yml`이 트리거되는지 확인 (이 PR 병합 직후 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)