### PR TITLE
fix: 카카오/애플 외부 API 호출에 타임아웃 명시

### DIFF
--- a/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
+++ b/src/main/java/org/runnect/server/auth/service/AppleSignInService.java
@@ -6,6 +6,7 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.jwk.source.RemoteJWKSet;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
@@ -52,6 +53,10 @@ public class AppleSignInService {
     @Value("${apple.revoke-url}")
     private String APPLE_REVOKE_URL;
     private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+    // 애플 공개키(JWKS) 조회 및 회원탈퇴 통보에 타임아웃을 명시한다. 기본값(무제한 대기)이면
+    // 애플 쪽이 응답을 늦게 줄 때 이 요청을 처리하던 톰캣 스레드가 계속 묶여있게 된다.
+    private static final int CONNECT_TIMEOUT_MS = 3000;
+    private static final int READ_TIMEOUT_MS = 3000;
 
     private PrivateKey PRIVATE_KEY;
     @Value("${apple.p8key}")
@@ -109,7 +114,9 @@ public class AppleSignInService {
     }
 
     private JWTClaimsSet verifySignatureAndGetClaims(String idToken) throws Exception {
-        JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(new URL(APPLE_JWKS_URL));
+        JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(
+                new URL(APPLE_JWKS_URL),
+                new DefaultResourceRetriever(CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS));
         ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
         JWSVerificationKeySelector<SecurityContext> keySelector =
                 new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keySource);
@@ -137,7 +144,11 @@ public class AppleSignInService {
 
         String clientSecret = createClientSecret();
 
-        OkHttpClient client = new OkHttpClient();
+        OkHttpClient client = new OkHttpClient.Builder()
+                .connectTimeout(CONNECT_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .readTimeout(READ_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .writeTimeout(READ_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .build();
 
         RequestBody formBody = new FormBody.Builder()
                 .add("token", appleAccessToken)

--- a/src/main/java/org/runnect/server/auth/service/KakaoSignInService.java
+++ b/src/main/java/org/runnect/server/auth/service/KakaoSignInService.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -21,6 +22,12 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class KakaoSignInService {
 
+    // 기본 RestTemplate은 타임아웃이 없어(무제한 대기), 카카오가 응답을 늦게 주면
+    // 그 요청을 처리하던 톰캣 스레드가 계속 묶여있게 된다. 스레드 풀이 이런 식으로
+    // 소진되면 카카오 로그인과 무관한 다른 API 요청까지 영향을 받는다.
+    private static final int CONNECT_TIMEOUT_MS = 3000;
+    private static final int READ_TIMEOUT_MS = 3000;
+
     public SocialInfoResponseDto getSocialInfo(String token) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -28,7 +35,7 @@ public class KakaoSignInService {
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
         HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
-        RestTemplate rt = new RestTemplate();
+        RestTemplate rt = new RestTemplate(createTimeoutRequestFactory());
 
         String userId = null;
         String email = null;
@@ -60,5 +67,12 @@ public class KakaoSignInService {
                     ErrorStatus.INVALID_KAKAO_ID_TOKEN_EXCEPTION.getMessage());
         }
         return SocialInfoResponseDto.of(email, userId);
+    }
+
+    private SimpleClientHttpRequestFactory createTimeoutRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+        return factory;
     }
 }


### PR DESCRIPTION
## 작업 배경
서킷 브레이커 도입을 검토하다가, 그보다 먼저 카카오/애플 로그인 호출에 **타임아웃 자체가 없다**는 걸 발견했다. `RestTemplate`/`OkHttpClient` 기본 생성자는 타임아웃이 없어서(무제한 대기), 카카오/애플이 응답을 늦게 주면 그 요청을 처리하던 톰캣 스레드가 계속 묶인다. 사용자가 재시도할수록 스레드가 하나씩 더 묶이고, 스레드 풀이 소진되면 로그인과 무관한 다른 API 요청까지 영향을 받는 구조였다(스레드 누수).

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `KakaoSignInService` | `RestTemplate`에 `SimpleClientHttpRequestFactory`로 connect/read timeout 3초 설정 |
| `AppleSignInService` | JWKS 조회(`RemoteJWKSet`)에 `DefaultResourceRetriever`로 타임아웃 지정, 회원탈퇴 통보(`OkHttpClient`)에도 동일 적용 |

Google은 `google-http-client` 자체 기본 타임아웃(20초)이 이미 있어 이번 변경에서 제외.

## 영향 범위
- 카카오/애플이 정상 응답하는 한 동작 변화 없음
- 카카오/애플이 3초 넘게 응답 안 하면, 예전엔 무제한 대기하던 게 이제 3초 후 예외(`UnauthorizedException` 계열)로 실패 처리됨 — 실패 자체는 동일하게 발생하던 상황(사용자는 결국 로그인 실패를 겪음)이고, 그 실패까지 걸리는 시간과 서버 스레드 점유 시간만 단축됨

## Test Plan
- [x] 로컬 postgres/redis 기동 후 `./gradlew test` 전체 254/254 통과
- [x] 기존 `AppleSignInServiceTest` 통과 확인 (Mock 기반이라 실제 타임아웃 동작은 검증 안 됨 — 실제 카카오/애플 서버 지연 상황 재현은 별도 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Apple and Kakao sign-in requests by applying connection and response time limits.
  * Apple account withdrawal requests now consistently honor configured network timeouts.
  * Prevented authentication requests from hanging indefinitely when external services are slow or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->