### PR TITLE
perf: FK 컬럼에 누락된 인덱스 5건 추가

### DIFF
--- a/src/main/java/org/runnect/server/course/entity/Course.java
+++ b/src/main/java/org/runnect/server/course/entity/Course.java
@@ -16,6 +16,9 @@ import org.runnect.server.user.entity.RunnectUser;
 
 @Getter
 @Entity
+@Table(indexes = {
+    @Index(name = "idx_course_user_id", columnList = "user_id")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Course extends AuditingTimeEntity {
 

--- a/src/main/java/org/runnect/server/health/entity/HeartRateSample.java
+++ b/src/main/java/org/runnect/server/health/entity/HeartRateSample.java
@@ -6,8 +6,10 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,9 @@ import org.runnect.server.common.entity.AuditingTimeEntity;
 
 @Getter
 @Entity
+@Table(indexes = {
+    @Index(name = "idx_heart_rate_sample_record_health_data_id", columnList = "record_health_data_id")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HeartRateSample extends AuditingTimeEntity {
 

--- a/src/main/java/org/runnect/server/record/entity/Record.java
+++ b/src/main/java/org/runnect/server/record/entity/Record.java
@@ -7,8 +7,10 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,9 @@ import org.runnect.server.user.entity.RunnectUser;
 
 @Getter
 @Entity
+@Table(indexes = {
+    @Index(name = "idx_record_user_id", columnList = "user_id")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Record extends AuditingTimeEntity {
 

--- a/src/main/java/org/runnect/server/scrap/entity/Scrap.java
+++ b/src/main/java/org/runnect/server/scrap/entity/Scrap.java
@@ -18,6 +18,8 @@ import javax.persistence.*;
         @UniqueConstraint(
                 columnNames = {"user_id", "public_course_id"}
         )
+}, indexes = {
+        @Index(name = "idx_scrap_public_course_id", columnList = "public_course_id")
 })
 @DynamicUpdate
 public class Scrap extends AuditingTimeEntity {

--- a/src/main/java/org/runnect/server/user/entity/UserStamp.java
+++ b/src/main/java/org/runnect/server/user/entity/UserStamp.java
@@ -10,6 +10,9 @@ import javax.persistence.*;
 
 @Getter
 @Entity
+@Table(indexes = {
+    @Index(name = "idx_user_stamp_user_id", columnList = "user_id")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserStamp extends AuditingTimeEntity {
 


### PR DESCRIPTION
## 작업 배경
- 백엔드 성능 최적화 지점을 찾던 중, PostgreSQL은 MySQL(InnoDB)과 달리 FK 컬럼을 자동으로 인덱싱하지 않는다는 점을 확인
- 실제로 `pg_indexes`로 조회해보니 `course.user_id`, `record.user_id`, `user_stamp.user_id`, `scrap.public_course_id`, `heart_rate_sample.record_health_data_id` 5개 FK 컬럼에 인덱스가 없었음
- 처음엔 `Course.path`(geometry) 컬럼에 GiST 공간 인덱스가 필요하다고 가정했으나, 코드 전체를 grep한 결과 공간 쿼리(ST_* 함수)를 실제로 사용하는 곳이 없어 기각 — FK 컬럼 누락이 진짜 후보였음

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `Course.java` | `@Table(indexes = {@Index(columnList = "user_id")})` 추가 |
| `Record.java` | `@Table(indexes = {@Index(columnList = "user_id")})` 추가 |
| `UserStamp.java` | `@Table(indexes = {@Index(columnList = "user_id")})` 추가 |
| `Scrap.java` | 기존 `uniqueConstraints`에 `indexes = {@Index(columnList = "public_course_id")}` 추가 |
| `HeartRateSample.java` | `@Table(indexes = {@Index(columnList = "record_health_data_id")})` 추가 |

`ddl-auto: update`로 스키마를 관리하므로 별도 마이그레이션 없이 배포 시 자동 반영됨.

## 선택지 및 근거
- **대안 1 (기각)**: 전체 FK 컬럼에 무조건 인덱스 추가 — 쓰기 비용이 늘어나므로 실제 조회 패턴에서 쓰이는 FK만 선별
- **대안 2 (기각)**: `Course.path`(geometry)에 GiST 공간 인덱스 추가 — grep으로 공간 쿼리 미사용 확인 후 기각. 불필요한 인덱스는 쓰기 성능만 깎아먹음
- **채택**: 실제 리포지토리에서 FK 기준으로 조회되는 컬럼에만 한정

## 영향 범위
- 마이페이지 코스/기록 목록, 유저 스탬프 조회, 스크랩 여부 확인, 심박수 샘플 조회 등 FK 기준 조회 전반
- 스키마 변경(인덱스 추가)만 있고 API 응답/동작은 동일 — 런타임 영향 없음, 조회 속도만 개선

### 검증 매트릭스

30만 건 규모 synthetic 데이터로 `EXPLAIN (ANALYZE, BUFFERS)` 직접 측정 (Docker 로컬 Postgres, 인덱스 추가 전/후 비교):

| 대상 | Before | After | 실행 계획 변화 |
| --- | --- | --- | --- |
| `course.user_id` | 52.516ms | 3.258ms | Seq Scan → Bitmap Heap Scan (`idx_course_user_id`) |
| `record.user_id` | 11.081ms | 2.704ms | Parallel Seq Scan → Bitmap Heap Scan (`idx_record_user_id`) |
| `user_stamp.user_id` | 15.984ms | 1.835ms | Seq Scan → Index Scan (`idx_user_stamp_user_id`) |
| `scrap.public_course_id` | 3.696ms | 1.233ms | Seq Scan → Bitmap Heap Scan (`idx_scrap_public_course_id`) |
| `heart_rate_sample.record_health_data_id` | 8.507ms | 0.429ms | Parallel Seq Scan → Bitmap Heap Scan (`idx_heart_rate_sample_record_health_data_id`) |

측정 후 synthetic 데이터는 전량 삭제, 실 데이터 baseline 행 수 복원 확인 완료.

## Test Plan
- [x] 로컬 전체 테스트 스위트 254개 통과 (`./gradlew test`, 실 Postgres/Redis 컨테이너 기준)
- [x] `EXPLAIN (ANALYZE, BUFFERS)`로 인덱스 전/후 실측 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved database query performance for courses, records, heart-rate samples, scraps, and user stamps.
  * Added indexes to frequently searched relationships and identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->