### PR TITLE
chore: gitignore가 application.yml을 놓치던 문제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ out/
 
 ### application.yml ###
 application.yaml
+application.yml
+src/main/resources/application.yml
+src/main/resources/application.yaml
 
 ### DS_Store
 .DS_Store


### PR DESCRIPTION
## 작업 배경
- 로컬 테스트용 `src/main/resources/application.yml`을 만들다가, `.gitignore`의 실제 패턴이 `application.yaml`(확장자 yaml)만 막고 있어 `application.yml`(확장자 yml)은 무시 대상이 아니라는 걸 발견 (`git check-ignore -v`로 확인)
- 지금은 더미값뿐이라 실제 유출은 없었지만, `git add -A`를 실수로 돌리면 로컬 DB 자격증명 등이 커밋될 수 있는 구멍이었음

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `.gitignore` | `application.yml`, `src/main/resources/application.yml`, `src/main/resources/application.yaml` 패턴 추가 |

## 영향 범위
- 설정 파일 무시 규칙만 추가, 런타임/로직 영향 없음

## Test Plan
- [x] `git check-ignore -v src/main/resources/application.yml`로 이제 무시됨을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)