### PR TITLE
ci: PR 변경 라인 기준 diff coverage 게이트 추가

### DIFF
--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -74,3 +76,12 @@ jobs:
           SPRING_DATASOURCE_USERNAME: runnect
           SPRING_DATASOURCE_PASSWORD: runnect_local_password
           SPRING_DATA_REDIS_HOST: localhost
+
+      # PR에서 새로 추가/수정된 라인만 커버리지를 검사한다 (전체 커버리지 게이트가 아님).
+      # 로직이 바뀌었는데 테스트가 안 따라오는 경우를 CI에서 기계적으로 잡기 위함.
+      - name: Diff coverage 게이트 (변경된 라인 기준)
+        run: |
+          pip install diff-cover
+          diff-cover build/reports/jacoco/test/jacocoTestReport.xml \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --fail-under=70

--- a/README.md
+++ b/README.md
@@ -212,6 +212,17 @@ public class SomeService {
 
 yml에 키가 없으면 기본값은 비활성(`false`)이다.
 
+### ✅ Diff Coverage 게이트
+
+PR에서 새로 추가/수정된 라인이 테스트로 커버되는지 CI(`build` job)가 자동으로 확인한다 — 로직을 고쳤는데 관련 테스트가 안 따라오는 경우를 기계적으로 잡기 위함. 전체 커버리지가 아니라 **이번 PR에서 바뀐 라인만** 대상으로 하며, 기준은 70%다.
+
+```bash
+# CI에서 실행되는 것과 동일한 방식으로 로컬에서 직접 확인
+./gradlew jacocoTestReport
+pip install diff-cover
+diff-cover build/reports/jacoco/test/jacocoTestReport.xml --compare-branch=origin/main
+```
+
 </aside>
 <hr>
 </br>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '2.7.14'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
@@ -79,4 +80,13 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+	}
 }


### PR DESCRIPTION
## 작업 배경
- 기존 CI(`prod-ci.yml`)는 `./gradlew build`로 기존 테스트 통과 여부만 확인 — 로직을 수정했는데 테스트를 안 고치거나, 새 로직을 추가했는데 테스트를 안 써도 CI는 그냥 초록불이었음
- 커버리지 측정/게이트 자체가 전무했음
- 전체 커버리지 게이트는 기존 미테스트 코드 때문에 처음부터 막혀버리므로, **PR에서 실제로 바뀐 라인만** 대상으로 하는 diff 기반 게이트를 채택

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `build.gradle` | `jacoco` 플러그인 추가, `jacocoTestReport`가 xml/html 리포트 생성하도록 설정, `test` 태스크에 `finalizedBy` 연결 |
| `.github/workflows/prod-ci.yml` | `actions/checkout`에 `fetch-depth: 0` 추가(base 브랜치 diff 비교용), `diff-cover`로 변경 라인 커버리지 70% 미만 시 CI 실패하는 스텝 추가 |
| `README.md` | "Diff Coverage 게이트" 섹션 추가, 로컬 재현 명령어 포함 |

## 선택지 및 근거
- **대안 1 (기각)**: 전체 커버리지 % 임계값 게이트 — 기존에 테스트 없는 코드가 이미 많아서 처음부터 막혀버림, 세팅만 하고 못 켜는 상태가 됨
- **대안 2 (기각)**: pitest 뮤테이션 테스트 — 이 규모/단계에 오버킬. "테스트가 있는데 부실한지"보다 먼저 "테스트가 없는지"부터 잡는 게 우선
- **채택**: diff 기반 커버리지(diff-cover) — PR에서 바뀐 라인만 검사하므로 기존 부채와 무관하게 "지금부터"를 강제할 수 있음

## 영향 범위
- CI 파이프라인에 스텝 하나 추가 — 런타임(애플리케이션) 동작에는 영향 없음
- 앞으로의 PR에서 변경 라인 커버리지가 70% 미만이면 `build` 체크가 실패함

### 검증 매트릭스
로컬에서 실제 검증(과거 PR #243의 diff를 대상으로 `diff-cover` 실행):

| 검증 내용 | 결과 |
| --- | --- |
| `./gradlew jacocoTestReport` 정상 생성 | ✅ `build/reports/jacoco/test/jacocoTestReport.xml` 생성 확인 |
| diff-cover가 실제 미테스트 라인을 잡아내는지 | ✅ `KakaoSignInService.java`(0%), `AppleSignInService.java`(16.7%) — PR #243에서 테스트 없이 추가된 타임아웃 로직을 정확히 검출 |
| 전체 빌드(`./gradlew build`) 통과 | ✅ BUILD SUCCESSFUL |

## Test Plan
- [x] 로컬에서 JaCoco 리포트 생성 확인
- [x] 실제 과거 diff로 diff-cover가 미테스트 라인을 정확히 검출하는지 검증
- [x] `./gradlew build` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)