### PR TITLE
perf: PublicCourseService.deletePublicCourses N+1 제거

### DIFF
--- a/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
+++ b/src/main/java/org/runnect/server/publicCourse/repository/PublicCourseRepository.java
@@ -22,6 +22,15 @@ public interface PublicCourseRepository  extends JpaRepository<PublicCourse, Lon
 
     List<PublicCourse> findByIdIn(Collection<Long> ids);
 
+    // deletePublicCourses에서 course/runnectUser(권한 검증)와 records(FK 해제)를 전부 순회하며
+    // 지연로딩을 트리거하던 N+1을 없애기 위한 전용 조회 (PublicCourseServiceTest 참고)
+    @Query("SELECT DISTINCT pc FROM PublicCourse pc " +
+            "JOIN FETCH pc.course c " +
+            "JOIN FETCH c.runnectUser " +
+            "LEFT JOIN FETCH pc.records " +
+            "WHERE pc.id IN :ids")
+    List<PublicCourse> findByIdInWithCourseAndRecords(@Param("ids") Collection<Long> ids);
+
     Long countBy();
 
     @Query("SELECT pc " +

--- a/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
+++ b/src/main/java/org/runnect/server/publicCourse/service/PublicCourseService.java
@@ -362,7 +362,7 @@ public class PublicCourseService {
                 .orElseThrow(() -> new NotFoundUserException(ErrorStatus.NOT_FOUND_USER_EXCEPTION,
                         ErrorStatus.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
-        List<PublicCourse> publicCourses = publicCourseRepository.findByIdIn(
+        List<PublicCourse> publicCourses = publicCourseRepository.findByIdInWithCourseAndRecords(
                 requestDto.getPublicCourseIdList());
 
 

--- a/src/test/java/org/runnect/server/publicCourse/service/PublicCourseServiceTest.java
+++ b/src/test/java/org/runnect/server/publicCourse/service/PublicCourseServiceTest.java
@@ -583,7 +583,7 @@ class PublicCourseServiceTest {
             PublicCourse publicCourse = buildPublicCourse(100L, course);
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-            when(publicCourseRepository.findByIdIn(Collections.singletonList(100L))).thenReturn(
+            when(publicCourseRepository.findByIdInWithCourseAndRecords(Collections.singletonList(100L))).thenReturn(
                 Collections.singletonList(publicCourse));
 
             DeletePublicCoursesResponseDto response = publicCourseService.deletePublicCourses(1L,
@@ -600,7 +600,7 @@ class PublicCourseServiceTest {
         void 존재하지_않는_공개코스_포함() {
             RunnectUser user = buildUser(1L);
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-            when(publicCourseRepository.findByIdIn(Arrays.asList(100L, 999L))).thenReturn(Collections.emptyList());
+            when(publicCourseRepository.findByIdInWithCourseAndRecords(Arrays.asList(100L, 999L))).thenReturn(Collections.emptyList());
 
             assertThatThrownBy(() -> publicCourseService.deletePublicCourses(1L,
                 new DeletePublicCoursesRequestDto(Arrays.asList(100L, 999L))))
@@ -618,7 +618,7 @@ class PublicCourseServiceTest {
             PublicCourse othersPublicCourse = buildPublicCourse(101L, buildCourse(11L, otherUser, false));
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-            when(publicCourseRepository.findByIdIn(Arrays.asList(100L, 101L))).thenReturn(
+            when(publicCourseRepository.findByIdInWithCourseAndRecords(Arrays.asList(100L, 101L))).thenReturn(
                 Arrays.asList(ownPublicCourse, othersPublicCourse));
 
             assertThatThrownBy(() -> publicCourseService.deletePublicCourses(1L,
@@ -637,7 +637,7 @@ class PublicCourseServiceTest {
             PublicCourse othersPublicCourse = buildPublicCourse(101L, buildCourse(11L, otherUser, false));
 
             when(userRepository.findById(adminId)).thenReturn(Optional.of(admin));
-            when(publicCourseRepository.findByIdIn(Collections.singletonList(101L))).thenReturn(
+            when(publicCourseRepository.findByIdInWithCourseAndRecords(Collections.singletonList(101L))).thenReturn(
                 Collections.singletonList(othersPublicCourse));
 
             DeletePublicCoursesResponseDto response = publicCourseService.deletePublicCourses(adminId,


### PR DESCRIPTION
## 작업 배경
- 이전 대화에서 나온 N+1 후보(`PublicCourseRepository.findByIdIn()`)를 실제로 검증하지 않고 남겨뒀던 항목
- 코드 추적 결과 `PublicCourseService.deletePublicCourses`에서 `findByIdIn`으로 조회한 `PublicCourse` 목록을 순회하며 `getCourse()`(OneToOne LAZY), `getCourse().getRunnectUser()`(ManyToOne LAZY), `getRecords()`(OneToMany LAZY)를 각각 호출 — 삭제 대상이 N개면 최대 3N+1 쿼리가 나가는 구조였음

## 변경 사항

| 영역 | 내용 |
| --- | --- |
| `PublicCourseRepository.java` | `findByIdInWithCourseAndRecords` 추가 — `course`/`course.runnectUser`/`records`를 JOIN FETCH로 한 번에 즉시로딩 |
| `PublicCourseService.java` | `deletePublicCourses`에서 `findByIdIn` → `findByIdInWithCourseAndRecords` 교체 |
| `PublicCourseServiceTest.java` | 위 변경에 맞춰 기존 4개 테스트의 mock 대상 메서드명 갱신 |

## 선택지 및 근거
- 새 쿼리는 즉흥적으로 만든 게 아니라, 같은 리포지토리의 `findById()`가 이미 프로덕션에서 쓰고 있는 `JOIN FETCH pc.course` 패턴을 그대로 확장한 것 — `JOIN FETCH c.runnectUser`, `LEFT JOIN FETCH pc.records` 추가는 이미 검증된 패턴의 자연스러운 연장

## 영향 범위
- `deletePublicCourses`(공개 코스 삭제 API) 쿼리 수만 변경, 응답/동작은 동일
- 대량 삭제 시일수록 쿼리 수 절감 효과가 커짐 (N개 삭제 시 최대 3N+1 → 1)

## 검증 관련 특이사항
- 로컬 `@DataJpaTest`로 실제 DB에 대해 JOIN FETCH 즉시로딩 여부를 검증하려 했으나, 로컬 Docker Postgres 컨테이너의 PostGIS 공유 라이브러리 결함(`$libdir/postgis-3` 없음 — 이 세션에서 이미 겪은 것과 동일한 로컬 전용 이슈)과 PgJDBC 드라이버의 타입 조회 방식이 얽혀 `course` 테이블에 새 row를 INSERT하는 것 자체가 로컬에서 막힘. raw psql/`PREPARE·EXECUTE`로는 동일 SQL이 정상 동작해, 코드 로직이 아니라 로컬 환경 결함으로 판단해 해당 통합 테스트는 제외함.
- 대신 다음 두 가지로 검증을 대체: (1) `ServerApplicationTests.contextLoads()`가 새 `@Query` JPQL을 엔티티 메타모델 기준으로 파싱/검증하며 통과 (2) 서비스 계층 mock 테스트 4건 갱신 후 통과

## Test Plan
- [x] 로컬 전체 테스트 254개 통과 (`./gradlew test`)
- [x] 코드 추적으로 N+1 실재 여부 확인 (FetchType.LAZY 3곳)
- [ ] 실제 DB 대상 JOIN FETCH 즉시로딩 통합 테스트 — 로컬 환경 결함으로 보류 (근본 원인은 코드가 아닌 로컬 PostGIS 라이브러리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)