### PR TITLE
fix: /ranking/me 500 에러 수정 (@UserId 리졸버 primitive long 미인식)

### DIFF
--- a/src/main/kotlin/org/runnect/server/ranking/controller/RecordRankingController.kt
+++ b/src/main/kotlin/org/runnect/server/ranking/controller/RecordRankingController.kt
@@ -31,10 +31,15 @@ class RecordRankingController(
     @GetMapping("course/{courseId}/ranking/me")
     @ResponseStatus(HttpStatus.OK)
     fun getMyRanking(
-        @UserId userId: Long,
+        // UserIdResolver#supportsParameter가 boxed java.lang.Long만 매칭한다.
+        // Kotlin의 non-null Long은 바이트코드상 primitive long으로 컴파일되어
+        // 리졸버가 파라미터를 아예 인식하지 못하므로, 반드시 nullable(Long?)로 선언해
+        // boxed Long으로 컴파일되게 한다. 실제로 null이 들어오는 경우는 없다 —
+        // 리졸버가 토큰이 없거나 유효하지 않으면 예외를 던진다.
+        @UserId userId: Long?,
         @PathVariable courseId: Long,
     ) = ApiResponseDto.success(
         SuccessStatus.GET_MY_RECORD_RANKING_SUCCESS,
-        recordRankingService.getMyRanking(courseId, userId),
+        recordRankingService.getMyRanking(courseId, requireNotNull(userId)),
     )
 }


### PR DESCRIPTION
## 작업 배경
- dev 배포 후 실기기 테스트 중 `GET /api/course/{courseId}/ranking/me`가 500을 반환하는 걸 발견

## 원인
`UserIdResolver#supportsParameter`는 `Long.class.equals(parameter.getParameterType())`로 boxed `java.lang.Long`만 매칭하는데, Kotlin 컨트롤러의 `@UserId userId: Long`(non-null)은 바이트코드상 primitive `long`으로 컴파일되어 리졸버가 파라미터를 인식하지 못함. 그 결과 토큰 검증 로직(`NullAccessTokenException` 등)을 타지 않고 엉뚱하게 500으로 떨어짐.

## 변경 사항
- `@UserId userId: Long?` (nullable)로 선언해 boxed `Long`으로 컴파일되게 수정
- 서비스 호출부는 `requireNotNull(userId)` 사용 (`!!` 대신)

## 검증
- 로컬 컴파일 확인
- dev에 배포 후 실기기로 재검증 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)